### PR TITLE
feat: hegemon-setup skill + make app/walletd targets

### DIFF
--- a/.claude/skills/hegemon-setup/SKILL.md
+++ b/.claude/skills/hegemon-setup/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: hegemon-setup
+description: Interactive first-run setup for a fresh Hegemon clone. Detects existing state, asks the user what they want to set up (CLI node, Electron desktop app, or full contributor flow), then orchestrates `make setup`, `make node`, `make walletd`, `npm install`, and `make check` in the right order with verification at each step. Use when the user clones the repo and asks to set it up, says "help me set up", "set up the repo", "first time", "fresh clone", or runs /hegemon-setup.
+metadata:
+  repo: Reflexivity/Hegemon
+  version: "1.0"
+---
+
+# Goal
+
+Walk a user (or yourself, on a fresh clone) through Hegemon setup without silently skipping optional components. The failure mode this skill prevents is: user runs `make setup && make node`, opens the Electron app, clicks "create wallet", and gets a confusing `walletd not found` error — because nothing in the default flow builds `walletd`.
+
+# How to use this skill
+
+You are the orchestrator. The user is in the repo root (`/Users/simon/dev/Hegemon` or wherever they cloned). Run the steps below in order. Narrate progress concisely. Verify each step before moving on.
+
+# Step 1 — Detect current state
+
+Before asking anything, run these checks in parallel and remember the results:
+
+```bash
+which cargo                                    # toolchain present?
+which node && node --version                   # npm/node present?
+which protoc                                   # substrate dep
+test -x ./target/release/hegemon-node && echo NODE_BUILT
+test -x ./target/release/walletd && echo WALLETD_BUILT
+test -d ./hegemon-app/node_modules && echo NPM_INSTALLED
+```
+
+If `cargo` is missing, the user has not run `make setup` yet — set toolchains_needed=true.
+
+# Step 2 — Ask the user one branching question
+
+Use AskUserQuestion. Present three options:
+
+- **(a) CLI node only** — *"Just run a Hegemon node from the terminal. Fastest, ~15 min cold build."*
+- **(b) Desktop app** — *"Run the Electron wallet/node app. Adds walletd + npm install, ~25 min total."*
+- **(c) Full contributor setup** — *"Everything in (b) plus `make check` to verify your environment passes fmt/lint/tests."*
+
+Skip the question only if the user has already specified ("set up everything", "just the CLI", "I want to use the app"). When in doubt, ask.
+
+# Step 3 — Execute, with verification
+
+Run only the steps the user's branch requires. Skip any step whose output already exists per Step 1.
+
+## 3a. Toolchains (all branches)
+
+```bash
+make setup
+```
+
+Verify: `which cargo` returns a path. If `make setup` fails, surface the error verbatim — do not retry blindly.
+
+## 3b. Build the node (all branches)
+
+```bash
+make node
+```
+
+This is the long step (10–20 min cold). Tell the user before kicking it off so they don't think Claude has hung.
+
+Verify: `./target/release/hegemon-node --version` runs without error.
+
+## 3c. Build walletd (branches b, c)
+
+```bash
+make walletd
+```
+
+Verify: `test -x ./target/release/walletd && ./target/release/walletd --help` runs.
+
+## 3d. Install JS deps (branches b, c)
+
+```bash
+cd hegemon-app && npm install
+```
+
+Verify: `test -d hegemon-app/node_modules`.
+
+## 3e. Run checks (branch c only)
+
+```bash
+make check
+```
+
+This runs fmt + lint + the full test suite. Long. If it fails, do not block the user — surface the failure and let them decide.
+
+# Step 4 — Print next-step commands
+
+Once the build branch the user picked is complete, print exactly the commands they should run next. Do not run these yourself — they're long-running foreground processes the user controls.
+
+**For all branches:**
+```
+HEGEMON_MINE=1 ./target/release/hegemon-node --dev --tmp
+```
+
+**For branches (b) and (c) — launching the desktop app:**
+```
+cd hegemon-app && npm run dev
+```
+
+# Important constraints
+
+- **Do not silently skip walletd.** If you detect the user is heading toward the Electron app (asking about wallet creation, mentioning the GUI, etc.), confirm walletd is built. The whole point of this skill is to surface that fork, not bury it.
+- **Ask before starting long builds** if the user hasn't already authorized them. `make node` on a cold cache pegs cores for 10+ minutes.
+- **Do not destroy state.** If `target/release/hegemon-node` already exists, do not rebuild unless the user asks. Detect-then-skip.
+- **macOS libclang quirk** — `make` targets call `./scripts/ensure-macos-libclang.sh` automatically; do not call cargo directly without setting `LIBCLANG_PATH` (see Makefile lines 8–19 for the macOS env handling).
+- **Stash unrelated dirty state** before running setup if the user has uncommitted work — they may have left in-progress changes. Confirm with the user first.
+
+# Reference: what each binary is for
+
+| Binary | Built by | Used by |
+|---|---|---|
+| `hegemon-node` | `make node` | CLI node, Electron app's node manager |
+| `walletd` | `make walletd` | Electron app's wallet daemon, `make wallet-demo`, testnet-join skill |
+
+The Electron app's binary resolver (`hegemon-app/electron/binPaths.ts`) looks for both binaries in `target/release/` (and `target/debug/`), walking up from the app dir.

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ PROVER_ARCHITECTURE_CONSTRAINTS.toc
 PROVER_ARCHITECTURE_CONSTRAINTS.synctex.gz
 config/testnet-config
 config/testnet-config
+
+# Local UX investigation notes (per-pain-point breakdowns, not for upstream)
+ux-investigation/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,21 @@ When writing complex features or significant refactors, use an ExecPlan (as desc
 
 # First-Run Setup
 
-Every fresh clone must begin with `make setup` followed by `make node`. The setup command installs toolchains, and `make node` builds the Substrate-based `hegemon-node` binary. Run `HEGEMON_MINE=1 ./target/release/hegemon-node --dev --tmp` to start a dev node with mining enabled.
+Setup is layered. Build only what the user needs — never silently skip an optional component, since failures surface later as confusing runtime errors (e.g. clicking "create wallet" in the Electron app fails if `walletd` was never built).
+
+**Mandatory (every fresh clone):**
+1. `make setup` — installs toolchains (Rust, Go, jq, clang-format, protoc, libclang).
+2. `make node` — builds `./target/release/hegemon-node`.
+
+**Optional add-ons — ASK the user which they want before building:**
+- **Desktop Electron app** → also requires `make walletd` (builds `./target/release/walletd`) plus `cd hegemon-app && npm install`. The app's `resolveBinaryPath` looks for both `hegemon-node` and `walletd` in `target/release/`. Convenience target: `make app` builds both Rust binaries.
+- **Benchmarks** → `make bench` (runs prover/wallet/network smoke benches; no prebuilt binary needed).
+- **Tests / contributor flow** → `make check` (fmt + lint + test).
+- **Wallet demo artifacts** → `make wallet-demo`.
+
+For an interactive walk-through that detects state, asks the right questions, and runs the right commands in order, invoke the `hegemon-setup` skill (`/hegemon-setup`) or accept a user request like "help me set up this repo" by running it.
+
+To start a dev node after `make node`: `HEGEMON_MINE=1 ./target/release/hegemon-node --dev --tmp`.
 
 # Design and Methods Docs
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-.PHONY: setup fmt lint test check bench wallet-demo quickstart node node-fast
+.PHONY: setup fmt lint test check bench wallet-demo quickstart node node-fast walletd app
 
 # macOS: librocksdb-sys requires libclang.dylib at runtime during build.
 # We still export the library path for make-driven builds, and the helper script
@@ -56,3 +56,13 @@ node:
 node-fast:
 	$(MACOS_LIBCLANG_HELPER)
 	cargo build -p hegemon-node --features substrate,fast-proofs --release
+
+# Build the walletd daemon (required by the Electron desktop app and the
+# wallet-demo / testnet-join flows). Not needed for CLI-only node operation.
+walletd:
+	$(MACOS_LIBCLANG_HELPER)
+	cargo build -p walletd --release
+
+# Build everything the Electron desktop app spawns at runtime: hegemon-node + walletd.
+# Run `npm install` inside hegemon-app/ separately for the JS side.
+app: node walletd

--- a/README.md
+++ b/README.md
@@ -278,9 +278,14 @@ Use this when you want to run two nodes that peer with each other:
 | --- | --- |
 | `make setup` | Runs `scripts/dev-setup.sh` to install toolchains and CLI prerequisites. |
 | `make node` | Builds the Substrate-based `hegemon-node` binary. |
+| `make node-fast` | Builds `hegemon-node` with `fast-proofs` enabled (development only). |
+| `make walletd` | Builds the `walletd` daemon (required for the Electron app, `make wallet-demo`, and the testnet-join flow). |
+| `make app` | Builds both Rust binaries the Electron desktop app spawns (`hegemon-node` + `walletd`). Run `npm install` in `hegemon-app/` separately for the JS side. |
 | `make check` | Formats, lints, and tests the entire Rust workspace. |
 | `make bench` | Executes the prover, wallet, and network smoke benchmarks. |
 | `make wallet-demo` | Generates example wallet artifacts plus a balance report inside `wallet-demo-artifacts/`. |
+
+> **Setting up the desktop app?** Run `make setup`, then `make app`, then `cd hegemon-app && npm install && npm run dev`. For an interactive walk-through in Claude Code that detects existing state and only builds what's missing, invoke the `hegemon-setup` skill (`/hegemon-setup`).
 
 ---
 

--- a/hegemon-app/README.md
+++ b/hegemon-app/README.md
@@ -1,0 +1,34 @@
+# hegemon-app
+
+Electron desktop app for Hegemon: node control + shielded wallet UI.
+
+## Required binaries
+
+The app spawns two Rust binaries from the workspace's `target/release/` directory at runtime:
+
+- `hegemon-node` — the Substrate-based chain node
+- `walletd` — the wallet daemon (created/opened on first wallet action)
+
+Both must be built from the **repo root** before launching the app. The Electron resolver (`electron/binPaths.ts`) walks up from this directory looking for them.
+
+## First-run setup
+
+From the repo root:
+
+```bash
+make setup       # toolchains, one-time
+make app         # builds hegemon-node + walletd
+cd hegemon-app
+npm install
+npm run dev
+```
+
+For an interactive walk-through that detects existing state and only builds what's missing, run `/hegemon-setup` in Claude Code or ask "help me set up the repo".
+
+## Override binary location
+
+Set `HEGEMON_BIN_DIR` to point the resolver at a custom directory (debug builds, release artifacts from CI, etc.):
+
+```bash
+HEGEMON_BIN_DIR=/path/to/bins npm run dev
+```


### PR DESCRIPTION
## Summary

A fresh clone running `make setup && make node` silently skips `walletd`. The Electron app then fails at runtime the moment a user clicks "create wallet" — the resolver throws `Binary "walletd" not found ... Expected build output at hegemon-app/target/release/walletd`. This PR makes the optional-build choice explicit instead of burying it.

## Changes

- **`Makefile`** — adds `make walletd` and `make app` (= `node` + `walletd`) targets. No behavior change to existing targets.
- **`CLAUDE.md`** — replaces the one-liner First-Run Setup with a layered model: mandatory (`make setup`, `make node`) vs optional add-ons (desktop app, benchmarks, tests, demos). Instructs Claude to ASK which branch the user wants before building, and to invoke the new skill for interactive setup.
- **`.claude/skills/hegemon-setup/SKILL.md`** — new skill. Triggered by `/hegemon-setup` or natural-language phrases like "set up the repo", "fresh clone", "first time". Detects existing state, asks the user a single branching question (CLI / desktop app / full contributor), then runs the right commands in order with verification at each step. Skips work that's already done.
- **`README.md`** — adds `make walletd`, `make app`, `make node-fast` rows to the Helpful targets table; adds a callout pointing desktop-app users at `make app` and the skill.
- **`hegemon-app/README.md`** — new short README so anyone landing in the app dir directly understands the binary dependencies and bootstrap steps.

## Why this shape

- The skill is the load-bearing user-visible piece, but it relies on clean Makefile targets — hence `make app` exists so the skill can call one command instead of re-implementing the flow.
- CLAUDE.md auto-loads into every session, so the "ask, don't silently skip" instruction fires for fresh-clone agents even when the user hasn't invoked the skill explicitly.
- The skill description includes natural-language triggers so it fires on `/hegemon-setup` *and* on plain English ("help me set this up").

## Test plan

- [ ] `make -n walletd` shows the expected `cargo build -p walletd --release` invocation (verified).
- [ ] `make -n app` shows both node and walletd builds (verified).
- [ ] On a fresh clone (or with `target/release/` cleared), `make app` builds both binaries to `target/release/`.
- [ ] In Claude Code, `/hegemon-setup` is recognized and walks through the branching flow.
- [ ] In Claude Code, asking "help me set up this repo" on a fresh clone triggers the skill via natural-language match.
- [ ] After `make app`, launching the Electron app and creating a wallet no longer throws `Binary "walletd" not found`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)