### PR TITLE
[codex] Refresh AI testnet join skills

### DIFF
--- a/.claude/skills/hegemon-testnet-join/SKILL.md
+++ b/.claude/skills/hegemon-testnet-join/SKILL.md
@@ -1,70 +1,75 @@
 ---
 name: hegemon-testnet-join
-description: Join the Hegemon testnet using the shared chainspec, verify genesis, sync to the tip, and enable mining safely on the live InlineTx path.
-compatibility: Requires ./target/release/hegemon-node, ./target/release/walletd, network access to hegemon.pauli.group:30333 and 158.69.222.121:30333, and a shared chainspec at config/dev-chainspec.json.
+description: Join the Hegemon testnet using the native 0.10 launch profile, verify genesis, sync to the tip, and choose relay or mining mode on the shipped recursive-block path.
+compatibility: Requires ./target/release/hegemon-node, network access to devnet.hegemonprotocol.com:30333, synchronized host time for mining, and ./target/release/walletd only when opening a wallet or exporting a mining address.
 metadata:
   repo: Reflexivity/Hegemon
-  version: "1.2"
+  version: "1.6"
 ---
 
 # Goal
-Connect a new node to the Hegemon testnet, verify it is on the canonical chain, and mine only after sync completes.
+Connect a Claude-assisted operator or end user to the public Hegemon 0.10 testnet without SSH, verify that the node is on the canonical chain, and enable mining only when this host is meant to author blocks.
 
 # Defaults
-- Approved public seed list: hegemon.pauli.group:30333,158.69.222.121:30333
-- Chain spec: config/dev-chainspec.json
-- Chainspec SHA-256: 455f552ec9e73bb07ad95ac8b9bf03c72461acc16ffd9afe738b70c31cce3cc1
-- RPC port: 9944
-- P2P listen: /ip4/0.0.0.0/tcp/30333
+- Network name: `Hegemon`.
+- Approved public join seed list: `devnet.hegemonprotocol.com:30333`.
+- Native profile: `--dev` on the 0.10 release binary. Do not use removed 0.9 JSON chainspec files, `config/dev-chainspec.json`, or `--chain`.
+- Default role: relay node / full node. Use mining mode only for an authoring host with a deliberate shielded payout address.
+- RPC port: `9944` for CLI examples.
+- P2P listen port: `30333` for a single host. Pick another local port if `30333` is already in use.
+- Shipped block path: native `tx_leaf` artifacts plus same-block `recursive_block_v2`. Legacy `InlineTx` is not the product path.
 
 # Steps
-1. Ensure binaries exist (fresh clones must run make setup and make node):
-   - make setup
-   - make node
-   - cargo build --release -p walletd
-2. Verify the shared chainspec matches the boot node. Do not use --chain dev.
-   - shasum -a 256 config/dev-chainspec.json
-   - Expected: 455f552ec9e73bb07ad95ac8b9bf03c72461acc16ffd9afe738b70c31cce3cc1
-3. Create or open a wallet and export the shielded mining address:
-   - export HEGEMON_MINER_ADDRESS=$(printf '%s\n{"id":1,"method":"status.get","params":{}}\n' "YOUR_PASSPHRASE" \
-     | ./target/release/walletd --store ~/.hegemon-wallet --mode open \
-     | jq -r '.result.primaryAddress')
-4. Start the node with the shared chainspec and seed:
-   - HEGEMON_MINE=1 \
-     HEGEMON_SEEDS="hegemon.pauli.group:30333,158.69.222.121:30333" \
-     HEGEMON_MINER_ADDRESS="$HEGEMON_MINER_ADDRESS" \
-     HEGEMON_PQ_STRICT_COMPATIBILITY=1 \
-     ./target/release/hegemon-node \
-       --dev \
-       --base-path ~/.hegemon-node \
-       --chain config/dev-chainspec.json \
-       --listen-addr /ip4/0.0.0.0/tcp/30333 \
-       --rpc-port 9944 \
-       --rpc-external \
-       --rpc-methods safe \
-       --name "TestnetNode"
-   - This is the live InlineTx path. Do not provision `hegemon-prover`, `hegemon-prover-worker`, or proof-sidecar / recursive flags for a normal testnet join.
-5. Monitor sync status and height. Mining pauses while syncing and resumes once caught up.
-   - curl -s -H "Content-Type: application/json" \
-     -d '{"id":1,"jsonrpc":"2.0","method":"system_health"}' \
-     http://127.0.0.1:9944 | jq
-   - curl -s -H "Content-Type: application/json" \
-     -d '{"id":1,"jsonrpc":"2.0","method":"hegemon_consensusStatus"}' \
-     http://127.0.0.1:9944 | jq
-   - curl -s -H "Content-Type: application/json" \
-     -d '{"id":1,"jsonrpc":"2.0","method":"chain_getHeader"}' \
-     http://127.0.0.1:9944 | jq
-6. If height stalls, check peers and genesis hash:
-   - curl -s -H "Content-Type: application/json" \
-     -d '{"id":1,"jsonrpc":"2.0","method":"chain_getBlockHash","params":[0]}' \
-     http://127.0.0.1:9944 | jq
-   - The returned genesis must match the already-synced trusted authoring node on the same chainspec.
-7. Sync wallet notes against the node RPC:
-   - printf '%s\n{"id":1,"method":"sync.once","params":{"ws_url":"ws://127.0.0.1:9944","force_rescan":false}}\n' "YOUR_PASSPHRASE" \
-     | ./target/release/walletd --store ~/.hegemon-wallet --mode open
+1. Ensure binaries exist. Fresh clones must run setup before starting a node:
+   - `make setup`
+   - `make node`
+   - `cargo build --release -p walletd` only if wallet or mining-address operations are needed.
+2. Confirm host time is synchronized before authoring. PoW block import rejects future-skewed timestamps.
+   - macOS: `sudo systemsetup -getusingnetworktime`
+   - Linux: `timedatectl status` or `chronyc tracking`
+3. Start a relay node first. This is the normal no-SSH join path for laptops and wallet users:
+   - `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333" \`
+   - `HEGEMON_PQ_STRICT_COMPATIBILITY=1 \`
+   - `./target/release/hegemon-node \`
+   - `  --dev \`
+   - `  --base-path ~/.hegemon-node \`
+   - `  --port 30333 \`
+   - `  --rpc-port 9944 \`
+   - `  --rpc-methods unsafe \`
+   - `  --name "HegemonRelay"`
+   - Keep RPC on loopback for normal wallet and desktop use. Do not add `--rpc-external` unless intentionally exposing RPC; exposed RPC must use `--rpc-methods safe`.
+4. Enable mining only for an authoring node with a known payout address:
+   - `export HEGEMON_MINER_ADDRESS=$(printf '%s\n{"id":1,"method":"status.get","params":{}}\n' "YOUR_PASSPHRASE" \`
+   - `  | ./target/release/walletd --store ~/.hegemon-wallet --mode open \`
+   - `  | jq -r '.result.primaryAddress')`
+   - Restart the node with mining enabled:
+   - `HEGEMON_MINE=1 \`
+   - `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333" \`
+   - `HEGEMON_MINER_ADDRESS="$HEGEMON_MINER_ADDRESS" \`
+   - `HEGEMON_PQ_STRICT_COMPATIBILITY=1 \`
+   - `./target/release/hegemon-node \`
+   - `  --dev \`
+   - `  --base-path ~/.hegemon-node \`
+   - `  --port 30333 \`
+   - `  --rpc-port 9944 \`
+   - `  --rpc-methods unsafe \`
+   - `  --name "HegemonAuthor"`
+   - Mining pauses while syncing and resumes only once caught up. All miners must use the same approved seed list to avoid partitions and forks.
+5. Monitor sync status, height, peers, and local profile:
+   - `curl -s -H "Content-Type: application/json" -d '{"id":1,"jsonrpc":"2.0","method":"system_health"}' http://127.0.0.1:9944 | jq`
+   - `curl -s -H "Content-Type: application/json" -d '{"id":1,"jsonrpc":"2.0","method":"chain_getHeader"}' http://127.0.0.1:9944 | jq`
+   - `curl -s -H "Content-Type: application/json" -d '{"id":1,"jsonrpc":"2.0","method":"system_peers"}' http://127.0.0.1:9944 | jq`
+   - `curl -s -H "Content-Type: application/json" -d '{"id":1,"jsonrpc":"2.0","method":"hegemon_nodeConfig"}' http://127.0.0.1:9944 | jq`
+6. If height stalls, compare genesis with a trusted synced node:
+   - `curl -s -H "Content-Type: application/json" -d '{"id":1,"jsonrpc":"2.0","method":"chain_getBlockHash","params":[0]}' http://127.0.0.1:9944 | jq`
+   - The returned genesis must match the already-synced trusted node on the same native release/profile.
+7. Sync wallet notes against the local node RPC:
+   - `printf '%s\n{"id":1,"method":"sync.once","params":{"ws_url":"ws://127.0.0.1:9944","force_rescan":false}}\n' "YOUR_PASSPHRASE" \`
+   - `  | ./target/release/walletd --store ~/.hegemon-wallet --mode open`
 
 # Notes
-- All miners should use the exact same `HEGEMON_SEEDS` list to avoid accidental forks/partitions. Keep private peer IPs out of public docs.
-- Keep host clock sync enabled (NTP/chrony). PoW import rejects future-skewed timestamps.
-- If the genesis hash or chainspec differ, stop the node and wipe the base path before restarting.
-- Keep RPC access locked down if you expose it beyond localhost.
+- The canonical public 0.10 join seed is `devnet.hegemonprotocol.com:30333`. Do not list legacy hostnames or raw IPs separately as fake redundancy; peers learn other addresses through P2P discovery.
+- Keep host clock sync enabled with NTP or chrony. PoW import rejects future-skewed timestamps.
+- If genesis differs, stop the node and wipe the base path before restarting with the matching release/profile.
+- Do not enter a public node RPC address into the desktop app. Run a local relay node with the approved seed and let the desktop connect to localhost.
+- Do not provision `hegemon-prover` or `hegemon-prover-worker` for a normal testnet join. The live path uses local native tx-leaf verification plus same-block `recursive_block_v2` artifacts.

--- a/.codex/skills/hegemon-testnet-join/SKILL.md
+++ b/.codex/skills/hegemon-testnet-join/SKILL.md
@@ -1,70 +1,75 @@
 ---
 name: hegemon-testnet-join
-description: Join the Hegemon testnet using the native 0.10 launch profile, verify genesis, sync to the tip, and enable mining safely on the live InlineTx path.
-compatibility: Requires ./target/release/hegemon-node, ./target/release/walletd, network access to devnet.hegemonprotocol.com:30333, and synchronized host time.
+description: Join the Hegemon testnet using the native 0.10 launch profile, verify genesis, sync to the tip, and choose relay or mining mode on the shipped recursive-block path.
+compatibility: Requires ./target/release/hegemon-node, network access to devnet.hegemonprotocol.com:30333, synchronized host time for mining, and ./target/release/walletd only when opening a wallet or exporting a mining address.
 metadata:
   repo: Reflexivity/Hegemon
-  version: "1.5"
+  version: "1.6"
 ---
 
 # Goal
-Connect a new node to the Hegemon testnet, verify it is on the canonical chain, and mine only after sync completes.
+Connect a Codex-assisted operator or end user to the public Hegemon 0.10 testnet without SSH, verify that the node is on the canonical chain, and enable mining only when this host is meant to author blocks.
 
 # Defaults
-- Approved public join seed list: devnet.hegemonprotocol.com:30333
-- Native profile: `--dev` on the 0.10 release binary. The 0.9 JSON chainspec files are not part of the native 0.10 launch surface.
-- RPC port: 9944
-- P2P listen port: 30333
+- Network name: `Hegemon`.
+- Approved public join seed list: `devnet.hegemonprotocol.com:30333`.
+- Native profile: `--dev` on the 0.10 release binary. Do not use removed 0.9 JSON chainspec files, `config/dev-chainspec.json`, or `--chain`.
+- Default role: relay node / full node. Use mining mode only for an authoring host with a deliberate shielded payout address.
+- RPC port: `9944` for CLI examples.
+- P2P listen port: `30333` for a single host. Pick another local port if `30333` is already in use.
+- Shipped block path: native `tx_leaf` artifacts plus same-block `recursive_block_v2`. Legacy `InlineTx` is not the product path.
 
 # Steps
-1. Ensure binaries exist (fresh clones must run make setup and make node):
-   - make setup
-   - make node
-   - cargo build --release -p walletd
+1. Ensure binaries exist. Fresh clones must run setup before starting a node:
+   - `make setup`
+   - `make node`
+   - `cargo build --release -p walletd` only if wallet or mining-address operations are needed.
 2. Confirm host time is synchronized before authoring. PoW block import rejects future-skewed timestamps.
    - macOS: `sudo systemsetup -getusingnetworktime`
    - Linux: `timedatectl status` or `chronyc tracking`
-3. Create or open a wallet and export the shielded mining address:
-   - export HEGEMON_MINER_ADDRESS=$(printf '%s\n{"id":1,"method":"status.get","params":{}}\n' "YOUR_PASSPHRASE" \
-     | ./target/release/walletd --store ~/.hegemon-wallet --mode open \
-     | jq -r '.result.primaryAddress')
-4. Start the node with the native profile and approved seed:
-   - HEGEMON_MINE=1 \
-     HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333" \
-     HEGEMON_MINER_ADDRESS="$HEGEMON_MINER_ADDRESS" \
-     HEGEMON_PQ_STRICT_COMPATIBILITY=1 \
-     ./target/release/hegemon-node \
-       --dev \
-       --base-path ~/.hegemon-node \
-       --port 30333 \
-       --rpc-port 9944 \
-       --rpc-external \
-       --rpc-methods safe \
-       --name "TestnetNode"
-   - This is the live InlineTx path. Do not provision `hegemon-prover`, `hegemon-prover-worker`, or proof-sidecar / recursive flags for a normal testnet join.
-   - If you are bringing up the first public authoring node after a fresh reset, omit `HEGEMON_SEEDS` or exclude the node's own public address until that first node is already live.
-5. Monitor sync status and height. Mining pauses while syncing and resumes once caught up.
-   - curl -s -H "Content-Type: application/json" \
-     -d '{"id":1,"jsonrpc":"2.0","method":"system_health"}' \
-     http://127.0.0.1:9944 | jq
-   - curl -s -H "Content-Type: application/json" \
-     -d '{"id":1,"jsonrpc":"2.0","method":"hegemon_consensusStatus"}' \
-     http://127.0.0.1:9944 | jq
-   - curl -s -H "Content-Type: application/json" \
-     -d '{"id":1,"jsonrpc":"2.0","method":"chain_getHeader"}' \
-     http://127.0.0.1:9944 | jq
-6. If height stalls, check peers and genesis hash:
-   - curl -s -H "Content-Type: application/json" \
-     -d '{"id":1,"jsonrpc":"2.0","method":"chain_getBlockHash","params":[0]}' \
-     http://127.0.0.1:9944 | jq
-   - The returned genesis must match the already-synced trusted authoring node on the same native release/profile.
-7. Sync wallet notes against the node RPC:
-   - printf '%s\n{"id":1,"method":"sync.once","params":{"ws_url":"ws://127.0.0.1:9944","force_rescan":false}}\n' "YOUR_PASSPHRASE" \
-     | ./target/release/walletd --store ~/.hegemon-wallet --mode open
+3. Start a relay node first. This is the normal no-SSH join path for laptops and wallet users:
+   - `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333" \`
+   - `HEGEMON_PQ_STRICT_COMPATIBILITY=1 \`
+   - `./target/release/hegemon-node \`
+   - `  --dev \`
+   - `  --base-path ~/.hegemon-node \`
+   - `  --port 30333 \`
+   - `  --rpc-port 9944 \`
+   - `  --rpc-methods unsafe \`
+   - `  --name "HegemonRelay"`
+   - Keep RPC on loopback for normal wallet and desktop use. Do not add `--rpc-external` unless intentionally exposing RPC; exposed RPC must use `--rpc-methods safe`.
+4. Enable mining only for an authoring node with a known payout address:
+   - `export HEGEMON_MINER_ADDRESS=$(printf '%s\n{"id":1,"method":"status.get","params":{}}\n' "YOUR_PASSPHRASE" \`
+   - `  | ./target/release/walletd --store ~/.hegemon-wallet --mode open \`
+   - `  | jq -r '.result.primaryAddress')`
+   - Restart the node with mining enabled:
+   - `HEGEMON_MINE=1 \`
+   - `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333" \`
+   - `HEGEMON_MINER_ADDRESS="$HEGEMON_MINER_ADDRESS" \`
+   - `HEGEMON_PQ_STRICT_COMPATIBILITY=1 \`
+   - `./target/release/hegemon-node \`
+   - `  --dev \`
+   - `  --base-path ~/.hegemon-node \`
+   - `  --port 30333 \`
+   - `  --rpc-port 9944 \`
+   - `  --rpc-methods unsafe \`
+   - `  --name "HegemonAuthor"`
+   - Mining pauses while syncing and resumes only once caught up. All miners must use the same approved seed list to avoid partitions and forks.
+5. Monitor sync status, height, peers, and local profile:
+   - `curl -s -H "Content-Type: application/json" -d '{"id":1,"jsonrpc":"2.0","method":"system_health"}' http://127.0.0.1:9944 | jq`
+   - `curl -s -H "Content-Type: application/json" -d '{"id":1,"jsonrpc":"2.0","method":"chain_getHeader"}' http://127.0.0.1:9944 | jq`
+   - `curl -s -H "Content-Type: application/json" -d '{"id":1,"jsonrpc":"2.0","method":"system_peers"}' http://127.0.0.1:9944 | jq`
+   - `curl -s -H "Content-Type: application/json" -d '{"id":1,"jsonrpc":"2.0","method":"hegemon_nodeConfig"}' http://127.0.0.1:9944 | jq`
+6. If height stalls, compare genesis with a trusted synced node:
+   - `curl -s -H "Content-Type: application/json" -d '{"id":1,"jsonrpc":"2.0","method":"chain_getBlockHash","params":[0]}' http://127.0.0.1:9944 | jq`
+   - The returned genesis must match the already-synced trusted node on the same native release/profile.
+7. Sync wallet notes against the local node RPC:
+   - `printf '%s\n{"id":1,"method":"sync.once","params":{"ws_url":"ws://127.0.0.1:9944","force_rescan":false}}\n' "YOUR_PASSPHRASE" \`
+   - `  | ./target/release/walletd --store ~/.hegemon-wallet --mode open`
 
 # Notes
-- All miners should use the exact same `HEGEMON_SEEDS` list to avoid accidental forks/partitions. Keep private peer IPs out of public docs.
-- The canonical public 0.10 dev join seed is `devnet.hegemonprotocol.com:30333`. Do not list legacy hostnames or raw IPs separately as fake redundancy.
-- Keep host clock sync enabled (NTP/chrony). PoW import rejects future-skewed timestamps.
-- If the genesis hash differs, stop the node and wipe the base path before restarting with the matching release/profile.
-- Keep RPC access locked down if you expose it beyond localhost.
+- The canonical public 0.10 join seed is `devnet.hegemonprotocol.com:30333`. Do not list legacy hostnames or raw IPs separately as fake redundancy; peers learn other addresses through P2P discovery.
+- Keep host clock sync enabled with NTP or chrony. PoW import rejects future-skewed timestamps.
+- If genesis differs, stop the node and wipe the base path before restarting with the matching release/profile.
+- Do not enter a public node RPC address into the desktop app. Run a local relay node with the approved seed and let the desktop connect to localhost.
+- Do not provision `hegemon-prover` or `hegemon-prover-worker` for a normal testnet join. The live path uses local native tx-leaf verification plus same-block `recursive_block_v2` artifacts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ When writing complex features or significant refactors, use an ExecPlan (as desc
 
 Every fresh clone must begin with `make setup` followed by `make node`. The setup command installs toolchains, and `make node` builds the native `hegemon-node` binary. Run `HEGEMON_MINE=1 ./target/release/hegemon-node --dev --tmp` to start a native dev node with mining enabled.
 
-For shared mining environments, document and use `HEGEMON_SEEDS="hegemon.pauli.group:30333"` unless the approved seed list has been deliberately rotated. All miners on the same network must share the same seed list to avoid partitions and forks, and mining hosts must keep NTP or chrony enabled because future-skewed PoW timestamps are rejected.
+For shared mining environments, document and use `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333"` unless the approved seed list has been deliberately rotated. All miners on the same network must share the same seed list to avoid partitions and forks, and mining hosts must keep NTP or chrony enabled because future-skewed PoW timestamps are rejected.
 
 # Design and Methods Docs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 The product must be made real, not a mock up. DON'T BE A SYCOPHANT CLAUDE.
 
+## Operator runbook updates
+
+- When documenting mining setup, always include guidance to set `HEGEMON_SEEDS` with the currently approved seed list and note that miners must share the same seeds to avoid forks.
+- Remind operators to enable time sync (NTP/chrony) because PoW timestamps are rejected if they exceed the future-skew bound.
+
 # ExecPlans
 
 When writing complex features or significant refactors, use an ExecPlan (as described in .agent/PLANS.md) from design to implementation.
@@ -9,6 +14,8 @@ When writing complex features or significant refactors, use an ExecPlan (as desc
 # First-Run Setup
 
 Every fresh clone must begin with `make setup` followed by `make node`. The setup command installs toolchains, and `make node` builds the native `hegemon-node` binary. Run `HEGEMON_MINE=1 ./target/release/hegemon-node --dev --tmp` to start a native dev node with mining enabled.
+
+For shared mining environments, document and use `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333"` unless the approved seed list has been deliberately rotated. All miners on the same network must share the same seed list to avoid partitions and forks, and mining hosts must keep NTP or chrony enabled because future-skewed PoW timestamps are rejected.
 
 # Design and Methods Docs
 


### PR DESCRIPTION
## Summary
- refresh the Codex and Claude `hegemon-testnet-join` skills for the native Hegemon 0.10 testnet profile
- replace stale 0.9 chainspec / old seed workflow with the current `devnet.hegemonprotocol.com:30333` seed, relay-first join path, optional mining payout setup, and recursive-block product path notes
- align `AGENTS.md` and `CLAUDE.md` operator guidance for shared seeds and NTP/chrony time sync

## Validation
- `git diff --check`
- searched AI-facing docs for stale `hegemon.pauli.group`, raw-IP seed, `config/dev-chainspec`, `--chain`, and `InlineTx` usage; remaining old-surface mentions are only explicit “do not use / legacy is not product path” warnings
