### PR TITLE
Fix public testnet sync and seed defaults

### DIFF
--- a/.claude/skills/hegemon-testnet-join/SKILL.md
+++ b/.claude/skills/hegemon-testnet-join/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hegemon-testnet-join
 description: Join the Hegemon testnet using the native 0.10 launch profile, verify genesis, sync to the tip, and choose relay or mining mode on the shipped recursive-block path.
-compatibility: Requires ./target/release/hegemon-node, network access to devnet.hegemonprotocol.com:30333, synchronized host time for mining, and ./target/release/walletd only when opening a wallet or exporting a mining address.
+compatibility: Requires ./target/release/hegemon-node, network access to hegemon.pauli.group:30333, synchronized host time for mining, and ./target/release/walletd only when opening a wallet or exporting a mining address.
 metadata:
   repo: Reflexivity/Hegemon
   version: "1.6"
@@ -12,7 +12,7 @@ Connect a Claude-assisted operator or end user to the public Hegemon 0.10 testne
 
 # Defaults
 - Network name: `Hegemon`.
-- Approved public join seed list: `devnet.hegemonprotocol.com:30333`.
+- Approved public join seed list: `hegemon.pauli.group:30333`.
 - Native profile: `--dev` on the 0.10 release binary. Do not use removed 0.9 JSON chainspec files, `config/dev-chainspec.json`, or `--chain`.
 - Default role: relay node / full node. Use mining mode only for an authoring host with a deliberate shielded payout address.
 - RPC port: `9944` for CLI examples.
@@ -28,7 +28,7 @@ Connect a Claude-assisted operator or end user to the public Hegemon 0.10 testne
    - macOS: `sudo systemsetup -getusingnetworktime`
    - Linux: `timedatectl status` or `chronyc tracking`
 3. Start a relay node first. This is the normal no-SSH join path for laptops and wallet users:
-   - `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333" \`
+   - `HEGEMON_SEEDS="hegemon.pauli.group:30333" \`
    - `HEGEMON_PQ_STRICT_COMPATIBILITY=1 \`
    - `./target/release/hegemon-node \`
    - `  --dev \`
@@ -44,7 +44,7 @@ Connect a Claude-assisted operator or end user to the public Hegemon 0.10 testne
    - `  | jq -r '.result.primaryAddress')`
    - Restart the node with mining enabled:
    - `HEGEMON_MINE=1 \`
-   - `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333" \`
+   - `HEGEMON_SEEDS="hegemon.pauli.group:30333" \`
    - `HEGEMON_MINER_ADDRESS="$HEGEMON_MINER_ADDRESS" \`
    - `HEGEMON_PQ_STRICT_COMPATIBILITY=1 \`
    - `./target/release/hegemon-node \`
@@ -68,7 +68,7 @@ Connect a Claude-assisted operator or end user to the public Hegemon 0.10 testne
    - `  | ./target/release/walletd --store ~/.hegemon-wallet --mode open`
 
 # Notes
-- The canonical public 0.10 join seed is `devnet.hegemonprotocol.com:30333`. Do not list legacy hostnames or raw IPs separately as fake redundancy; peers learn other addresses through P2P discovery.
+- The canonical public 0.10 join seed is `hegemon.pauli.group:30333`. Do not list legacy hostnames or raw IPs separately as fake redundancy; peers learn other addresses through P2P discovery.
 - Keep host clock sync enabled with NTP or chrony. PoW import rejects future-skewed timestamps.
 - If genesis differs, stop the node and wipe the base path before restarting with the matching release/profile.
 - Do not enter a public node RPC address into the desktop app. Run a local relay node with the approved seed and let the desktop connect to localhost.

--- a/.codex/skills/hegemon-testnet-join/SKILL.md
+++ b/.codex/skills/hegemon-testnet-join/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hegemon-testnet-join
 description: Join the Hegemon testnet using the native 0.10 launch profile, verify genesis, sync to the tip, and choose relay or mining mode on the shipped recursive-block path.
-compatibility: Requires ./target/release/hegemon-node, network access to devnet.hegemonprotocol.com:30333, synchronized host time for mining, and ./target/release/walletd only when opening a wallet or exporting a mining address.
+compatibility: Requires ./target/release/hegemon-node, network access to hegemon.pauli.group:30333, synchronized host time for mining, and ./target/release/walletd only when opening a wallet or exporting a mining address.
 metadata:
   repo: Reflexivity/Hegemon
   version: "1.6"
@@ -12,7 +12,7 @@ Connect a Codex-assisted operator or end user to the public Hegemon 0.10 testnet
 
 # Defaults
 - Network name: `Hegemon`.
-- Approved public join seed list: `devnet.hegemonprotocol.com:30333`.
+- Approved public join seed list: `hegemon.pauli.group:30333`.
 - Native profile: `--dev` on the 0.10 release binary. Do not use removed 0.9 JSON chainspec files, `config/dev-chainspec.json`, or `--chain`.
 - Default role: relay node / full node. Use mining mode only for an authoring host with a deliberate shielded payout address.
 - RPC port: `9944` for CLI examples.
@@ -28,7 +28,7 @@ Connect a Codex-assisted operator or end user to the public Hegemon 0.10 testnet
    - macOS: `sudo systemsetup -getusingnetworktime`
    - Linux: `timedatectl status` or `chronyc tracking`
 3. Start a relay node first. This is the normal no-SSH join path for laptops and wallet users:
-   - `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333" \`
+   - `HEGEMON_SEEDS="hegemon.pauli.group:30333" \`
    - `HEGEMON_PQ_STRICT_COMPATIBILITY=1 \`
    - `./target/release/hegemon-node \`
    - `  --dev \`
@@ -44,7 +44,7 @@ Connect a Codex-assisted operator or end user to the public Hegemon 0.10 testnet
    - `  | jq -r '.result.primaryAddress')`
    - Restart the node with mining enabled:
    - `HEGEMON_MINE=1 \`
-   - `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333" \`
+   - `HEGEMON_SEEDS="hegemon.pauli.group:30333" \`
    - `HEGEMON_MINER_ADDRESS="$HEGEMON_MINER_ADDRESS" \`
    - `HEGEMON_PQ_STRICT_COMPATIBILITY=1 \`
    - `./target/release/hegemon-node \`
@@ -68,7 +68,7 @@ Connect a Codex-assisted operator or end user to the public Hegemon 0.10 testnet
    - `  | ./target/release/walletd --store ~/.hegemon-wallet --mode open`
 
 # Notes
-- The canonical public 0.10 join seed is `devnet.hegemonprotocol.com:30333`. Do not list legacy hostnames or raw IPs separately as fake redundancy; peers learn other addresses through P2P discovery.
+- The canonical public 0.10 join seed is `hegemon.pauli.group:30333`. Do not list legacy hostnames or raw IPs separately as fake redundancy; peers learn other addresses through P2P discovery.
 - Keep host clock sync enabled with NTP or chrony. PoW import rejects future-skewed timestamps.
 - If genesis differs, stop the node and wipe the base path before restarting with the matching release/profile.
 - Do not enter a public node RPC address into the desktop app. Run a local relay node with the approved seed and let the desktop connect to localhost.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ When writing complex features or significant refactors, use an ExecPlan (as desc
 
 Every fresh clone must begin with `make setup` followed by `make node`. The setup command installs toolchains, and `make node` builds the native `hegemon-node` binary. Run `HEGEMON_MINE=1 ./target/release/hegemon-node --dev --tmp` to start a native dev node with mining enabled.
 
-For shared mining environments, document and use `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333"` unless the approved seed list has been deliberately rotated. All miners on the same network must share the same seed list to avoid partitions and forks, and mining hosts must keep NTP or chrony enabled because future-skewed PoW timestamps are rejected.
+For shared mining environments, document and use `HEGEMON_SEEDS="hegemon.pauli.group:30333"` unless the approved seed list has been deliberately rotated. All miners on the same network must share the same seed list to avoid partitions and forks, and mining hosts must keep NTP or chrony enabled because future-skewed PoW timestamps are rejected.
 
 # Design and Methods Docs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ When writing complex features or significant refactors, use an ExecPlan (as desc
 
 Every fresh clone must begin with `make setup` followed by `make node`. The setup command installs toolchains, and `make node` builds the native `hegemon-node` binary. Run `HEGEMON_MINE=1 ./target/release/hegemon-node --dev --tmp` to start a native dev node with mining enabled.
 
-For shared mining environments, document and use `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333"` unless the approved seed list has been deliberately rotated. All miners on the same network must share the same seed list to avoid partitions and forks, and mining hosts must keep NTP or chrony enabled because future-skewed PoW timestamps are rejected.
+For shared mining environments, document and use `HEGEMON_SEEDS="hegemon.pauli.group:30333"` unless the approved seed list has been deliberately rotated. All miners on the same network must share the same seed list to avoid partitions and forks, and mining hosts must keep NTP or chrony enabled because future-skewed PoW timestamps are rejected.
 
 # Design and Methods Docs
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Key options:
 - `--base-path <PATH>` - Persistent database location
 - `--rpc-port <PORT>` - JSON-RPC port (default: 9944)
 - `--port <PORT>` - P2P port (default: 30333)
-- `HEGEMON_SEEDS=<host:port,...>` - Bootstrap peers for native P2P sync. Shared miners must use the same approved seed list, currently `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333"`, to avoid forks.
+- `HEGEMON_SEEDS=<host:port,...>` - Bootstrap peers for native P2P sync. Shared miners must use the same approved seed list, currently `HEGEMON_SEEDS="hegemon.pauli.group:30333"`, to avoid forks.
 
 Environment variables:
 - `HEGEMON_MINE=1` - Enable mining

--- a/config/formal-security-blueprint.json
+++ b/config/formal-security-blueprint.json
@@ -5853,7 +5853,7 @@
             {
               "caller": "native_sync_loop",
               "callee_must_precede": [
-                "node.block_range"
+                "range_node.block_range"
               ],
               "must_dominate_successors": true,
               "lean_theorems": [
@@ -10003,7 +10003,7 @@
               "caller": "native_sync_loop",
               "callee_must_precede": [
                 "node.import_announced_block",
-                "node.block_range",
+                "range_node.block_range",
                 "admit_and_sort_native_sync_response_blocks"
               ],
               "must_dominate_successors": true,

--- a/config/testnet/README.md
+++ b/config/testnet/README.md
@@ -125,7 +125,7 @@ The soak test monitors:
 To connect an external node to the testnet:
 
 ```bash
-HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333" \
+HEGEMON_SEEDS="hegemon.pauli.group:30333" \
 hegemon-node \
     --dev \
     --base-path=/data/hegemon \
@@ -133,6 +133,10 @@ hegemon-node \
     --rpc-port=9944 \
     --name=my-node
 ```
+
+The public Hegemon 0.10 testnet seed is `hegemon.pauli.group:30333`. Do not use
+the dev host as the public join target unless the approved seed list has been
+deliberately rotated.
 
 ## Connecting Wallet
 

--- a/formal/lean/Hegemon/Native/SyncAdmission.lean
+++ b/formal/lean/Hegemon/Native/SyncAdmission.lean
@@ -126,10 +126,10 @@ def miningSyncObservedPeerHeight
   if input.stoppedOnError then
     none
   else if input.verifiedNewProgress then
-    some input.localBestHeight
+    some input.peerBestHeight
   else if input.verifiedKnownAtOrBelowLocalBest
       && input.peerBestHeight ≤ input.localBestHeight then
-    some input.peerBestHeight
+    some input.localBestHeight
   else
     none
 
@@ -362,23 +362,45 @@ theorem mining_sync_observation_none_on_error
   unfold miningSyncObservedPeerHeight
   simp [stopped]
 
-theorem mining_sync_observation_imported_progress_uses_local_best
+theorem mining_sync_observation_imported_progress_uses_peer_best
     {input : MiningSyncEvidenceInput}
     (notStopped : input.stoppedOnError = false)
     (newProgress : input.verifiedNewProgress = true) :
-    miningSyncObservedPeerHeight input = some input.localBestHeight := by
+    miningSyncObservedPeerHeight input = some input.peerBestHeight := by
   unfold miningSyncObservedPeerHeight
   simp [notStopped, newProgress]
 
-theorem mining_sync_observation_known_peer_uses_peer_height
+theorem mining_sync_observation_known_peer_at_or_below_local_best
     {input : MiningSyncEvidenceInput}
     (notStopped : input.stoppedOnError = false)
     (noNewProgress : input.verifiedNewProgress = false)
     (known : input.verifiedKnownAtOrBelowLocalBest = true)
-    (within : input.peerBestHeight ≤ input.localBestHeight) :
-    miningSyncObservedPeerHeight input = some input.peerBestHeight := by
+    (notAhead : input.peerBestHeight ≤ input.localBestHeight) :
+    miningSyncObservedPeerHeight input = some input.localBestHeight := by
   unfold miningSyncObservedPeerHeight
-  simp [notStopped, noNewProgress, known, within]
+  simp [notStopped, noNewProgress, known, notAhead]
+
+theorem mining_sync_observation_unknown_or_ahead_peer_rejected
+    {input : MiningSyncEvidenceInput}
+    (notStopped : input.stoppedOnError = false)
+    (noNewProgress : input.verifiedNewProgress = false)
+    (unknownOrAhead :
+      input.verifiedKnownAtOrBelowLocalBest = false
+        ∨ ¬ input.peerBestHeight ≤ input.localBestHeight) :
+    miningSyncObservedPeerHeight input = none := by
+  unfold miningSyncObservedPeerHeight
+  cases unknownOrAhead with
+  | inl unknown =>
+      simp [notStopped, noNewProgress, unknown]
+  | inr ahead =>
+      by_cases known : input.verifiedKnownAtOrBelowLocalBest = true
+      · simp [notStopped, noNewProgress, known, ahead]
+      · have unknown : input.verifiedKnownAtOrBelowLocalBest = false := by
+          cases h : input.verifiedKnownAtOrBelowLocalBest
+          · rfl
+          · exfalso
+            exact known h
+        simp [notStopped, noNewProgress, unknown]
 
 theorem mining_gate_seeded_follows_observed_gate
     {input : MiningGateInput}
@@ -752,8 +774,12 @@ theorem mining_gate_seeded_open_allows :
     miningGateAllowsWork miningGateSeededOpen = true := by
   decide
 
-theorem mining_evidence_known_equal_tip_observes_peer_height :
+theorem mining_evidence_known_equal_tip_observes_local_tip :
     miningSyncObservedPeerHeight miningEvidenceKnownEqualTip = some 12 := by
+  decide
+
+theorem mining_evidence_known_below_tip_observes_local_tip :
+    miningSyncObservedPeerHeight miningEvidenceKnownBelowTip = some 12 := by
   decide
 
 theorem mining_evidence_known_ahead_rejects :

--- a/hegemon-app/electron/nodeManager.ts
+++ b/hegemon-app/electron/nodeManager.ts
@@ -2,21 +2,36 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import type { NodePeerSnapshot, NodeStartOptions, NodeSummary, NodeSummaryRequest } from '../src/types';
+import type {
+  CanonicalCheckpointStatus,
+  NodePeerSnapshot,
+  NodeStartOptions,
+  NodeSummary,
+  NodeSummaryRequest
+} from '../src/types';
 import { resolveBinaryPath } from './binPaths';
 import { applyEnvDefaults, copyParentEnv, createBaseChildEnv, setEnvValue } from './childProcessEnv';
 
 const DEFAULT_RPC_PORT = 9955;
 const CANONICAL_TESTNET_P2P_PORT = 30333;
 const LEGACY_TESTNET_P2P_PORT = 31333;
-const APPROVED_SEEDS = 'devnet.hegemonprotocol.com:30333';
+const APPROVED_SEEDS = 'hegemon.pauli.group:30333';
+const PUBLIC_TESTNET_NAME = 'Hegemon';
+const CANONICAL_TESTNET_CHECKPOINTS = [
+  {
+    height: 2048,
+    hash: '0x00000000e930672262cba74a26750c0540a1e2aa54e7ad27ffc1e6fbd055bc4e'
+  },
+  {
+    height: 4096,
+    hash: '0x0000001891cd8a0b45add76b6b0ebe6bc50f6f1dc60879f9f000a71cf22ad5de'
+  }
+] as const;
 const LEGACY_SEED_ALIASES: Record<string, string> = {
   'hegemon.pauli.group:31333': APPROVED_SEEDS,
   'hegemon.pauli.group:30333': APPROVED_SEEDS,
   '158.69.222.121:31333': APPROVED_SEEDS,
-  '158.69.222.121:30333': APPROVED_SEEDS,
-  'devnet.hegemonprotocol.com:30333': APPROVED_SEEDS,
-  '51.222.86.107:30333': APPROVED_SEEDS
+  '158.69.222.121:30333': APPROVED_SEEDS
 };
 const DEFAULT_LOCAL_BASE_PATH = '~/.hegemon-node';
 const DEFAULT_DEV_010_BASE_PATH = '~/.hegemon-node-native-010-dev';
@@ -388,6 +403,7 @@ export class NodeManager extends EventEmitter {
         syncTargetHeight: null,
         pendingExtrinsics: null,
         peerList: null,
+        canonicalCheckpoint: null,
         supplyDigest: null,
         storage: null,
         telemetry: null,
@@ -423,6 +439,7 @@ export class NodeManager extends EventEmitter {
         syncTargetHeight: null,
         pendingExtrinsics: null,
         peerList: null,
+        canonicalCheckpoint: null,
         supplyDigest: null,
         storage: null,
         telemetry: null,
@@ -443,6 +460,7 @@ export class NodeManager extends EventEmitter {
     const pendingExtrinsics = await this.safeRpcCall('author_pendingExtrinsics', [], httpUrl);
     const peerList = await this.safeRpcCall('hegemon_peerList', [], httpUrl);
     const bestNumber = finiteNumberOrNull(consensus?.height);
+    const canonicalCheckpoint = await this.readCanonicalCheckpoint(httpUrl, bestNumber);
     const consensusSyncTarget = finiteNumberOrNull(consensus?.sync_target_height ?? consensus?.syncTargetHeight);
     const miningSyncTarget = finiteNumberOrNull(mining?.sync_target_height ?? mining?.syncTargetHeight);
     const syncTargetHeight =
@@ -491,6 +509,7 @@ export class NodeManager extends EventEmitter {
       syncTargetHeight,
       pendingExtrinsics: Array.isArray(pendingExtrinsics) ? pendingExtrinsics.length : null,
       peerList: normalizePeerList(peerList),
+      canonicalCheckpoint,
       supplyDigest: consensus?.supply_digest ? String(consensus.supply_digest) : null,
       storage: storage
         ? {
@@ -529,6 +548,75 @@ export class NodeManager extends EventEmitter {
           }
         : null,
       updatedAt: new Date().toISOString()
+    };
+  }
+
+  private async readCanonicalCheckpoint(
+    httpUrl: string,
+    bestNumber: number | null
+  ): Promise<CanonicalCheckpointStatus> {
+    if (bestNumber === null) {
+      return {
+        network: PUBLIC_TESTNET_NAME,
+        seed: APPROVED_SEEDS,
+        status: 'unavailable',
+        height: null,
+        expectedHash: null,
+        actualHash: null,
+        detail: 'No local height is available yet.'
+      };
+    }
+
+    const checkpoint = [...CANONICAL_TESTNET_CHECKPOINTS]
+      .reverse()
+      .find((candidate) => bestNumber >= candidate.height);
+    if (!checkpoint) {
+      return {
+        network: PUBLIC_TESTNET_NAME,
+        seed: APPROVED_SEEDS,
+        status: 'pending',
+        height: CANONICAL_TESTNET_CHECKPOINTS[0].height,
+        expectedHash: CANONICAL_TESTNET_CHECKPOINTS[0].hash,
+        actualHash: null,
+        detail: `Waiting to reach checkpoint height ${CANONICAL_TESTNET_CHECKPOINTS[0].height}.`
+      };
+    }
+
+    const actualHash = await this.safeRpcCall('chain_getBlockHash', [checkpoint.height], httpUrl);
+    const actualHashString = typeof actualHash === 'string' ? actualHash.toLowerCase() : null;
+    const expectedHashString = checkpoint.hash.toLowerCase();
+    if (!actualHashString) {
+      return {
+        network: PUBLIC_TESTNET_NAME,
+        seed: APPROVED_SEEDS,
+        status: 'unavailable',
+        height: checkpoint.height,
+        expectedHash: checkpoint.hash,
+        actualHash: null,
+        detail: `Could not read block hash at checkpoint height ${checkpoint.height}.`
+      };
+    }
+
+    if (actualHashString !== expectedHashString) {
+      return {
+        network: PUBLIC_TESTNET_NAME,
+        seed: APPROVED_SEEDS,
+        status: 'mismatch',
+        height: checkpoint.height,
+        expectedHash: checkpoint.hash,
+        actualHash: String(actualHash),
+        detail: `Local chain does not match the Hegemon testnet checkpoint at height ${checkpoint.height}.`
+      };
+    }
+
+    return {
+      network: PUBLIC_TESTNET_NAME,
+      seed: APPROVED_SEEDS,
+      status: 'verified',
+      height: checkpoint.height,
+      expectedHash: checkpoint.hash,
+      actualHash: String(actualHash),
+      detail: `Matched the Hegemon testnet checkpoint at height ${checkpoint.height}.`
     };
   }
 

--- a/hegemon-app/scripts/check-ui-guards.mjs
+++ b/hegemon-app/scripts/check-ui-guards.mjs
@@ -39,7 +39,7 @@ const legacyContact = {
 };
 const ovhContact = {
   id: 'legacy-ovh',
-  name: 'old hegemon-ovh wallet',
+  name: 'hegemon-ovh wallet',
   address: 'shca1...',
   verified: true
 };
@@ -53,7 +53,7 @@ const currentContact = {
 };
 
 assert.match(legacyContactWarning(legacyContact), /Legacy contact/);
-assert.match(legacyContactWarning(ovhContact), /Legacy contact/);
+assert.equal(legacyContactWarning(ovhContact), null);
 assert.equal(legacyContactWarning(currentContact), null);
 
 const startupRace = computeNodeDisplayState({
@@ -63,7 +63,8 @@ const startupRace = computeNodeDisplayState({
   bestNumber: 1370,
   syncTargetHeight: 0,
   mining: true,
-  miningSyncGateOpen: false
+  miningSyncGateOpen: false,
+  canonicalCheckpoint: { status: 'verified' }
 });
 assert.equal(startupRace.startupSummarySettling, true);
 assert.equal(startupRace.syncTargetHeight, 1370);
@@ -81,7 +82,8 @@ const genuineMiningGate = computeNodeDisplayState({
   bestNumber: 1360,
   syncTargetHeight: 1370,
   mining: true,
-  miningSyncGateOpen: false
+  miningSyncGateOpen: false,
+  canonicalCheckpoint: { status: 'verified' }
 });
 assert.equal(genuineMiningGate.startupSummarySettling, false);
 assert.equal(genuineMiningGate.syncTargetHeight, 1370);
@@ -99,13 +101,28 @@ const localMinerAhead = computeNodeDisplayState({
   bestNumber: 1488,
   syncTargetHeight: 1487,
   mining: true,
-  miningSyncGateOpen: true
+  miningSyncGateOpen: true,
+  canonicalCheckpoint: { status: 'verified' }
 });
 assert.equal(localMinerAhead.heightDelta, 1);
 assert.equal(localMinerAhead.heightRelation, 'local_ahead');
 assert.equal(localMinerAhead.miningGateBlocked, false);
 assert.equal(localMinerAhead.healthLabel, 'Healthy');
 assert.equal(localMinerAhead.healthTone, 'ok');
+
+const forkedSameHeight = computeNodeDisplayState({
+  reachable: true,
+  peers: 2,
+  isSyncing: false,
+  bestNumber: 4802,
+  syncTargetHeight: 4802,
+  mining: false,
+  miningSyncGateOpen: null,
+  canonicalCheckpoint: { status: 'mismatch' }
+});
+assert.equal(forkedSameHeight.heightRelation, 'aligned');
+assert.equal(forkedSameHeight.healthLabel, 'Forked');
+assert.equal(forkedSameHeight.healthTone, 'error');
 
 const offline = computeNodeDisplayState({
   reachable: false,
@@ -143,6 +160,21 @@ assert.equal(
   nodeManagerSource.includes('process.env.HEGEMON_MINER_ADDRESS'),
   false,
   'Managed desktop mining must not inherit a hidden parent HEGEMON_MINER_ADDRESS.'
+);
+assert.match(
+  appSource,
+  /const buildDefaultConnections = \(\) => \[buildDefaultConnection\(\)\];/,
+  'The app must expose one default launch path: managed local Hegemon testnet.'
+);
+assert.match(
+  appSource,
+  /findDefaultManagedConnection/,
+  'Unreachable stale profiles must fall back to the canonical managed local Hegemon profile.'
+);
+assert.equal(
+  appSource.includes('devnet.hegemonprotocol.com'),
+  false,
+  'The public desktop default must not reference the retired devnet seed.'
 );
 
 console.log('app UI guard checks passed');

--- a/hegemon-app/src/App.tsx
+++ b/hegemon-app/src/App.tsx
@@ -25,7 +25,7 @@ const shieldedAddressPrefix = 'shca1';
 const shieldedAddressLength = 2634;
 const shieldedAddressDataCharset = /^[023456789acdefghjklmnpqrstuvwxyz]+$/;
 const shieldedAddressSeparatorPattern = /[\s\u200B\u200C\u200D\uFEFF]+/g;
-const approvedSeeds = 'devnet.hegemonprotocol.com:30333';
+const approvedSeeds = 'hegemon.pauli.group:30333';
 const hegemonNetworkName = 'Hegemon';
 const hegemonNetworkVersionLabel = 'Hegemon 0.10';
 const defaultDevConnectionLabel = hegemonNetworkName;
@@ -43,9 +43,7 @@ const legacySeedAliases: Record<string, string> = {
   'hegemon.pauli.group:31333': approvedSeeds,
   'hegemon.pauli.group:30333': approvedSeeds,
   '158.69.222.121:31333': approvedSeeds,
-  '158.69.222.121:30333': approvedSeeds,
-  'devnet.hegemonprotocol.com:30333': approvedSeeds,
-  '51.222.86.107:30333': approvedSeeds
+  '158.69.222.121:30333': approvedSeeds
 };
 const connectionsKey = 'hegemon.nodeConnections';
 const activeConnectionKey = 'hegemon.activeConnection';
@@ -866,30 +864,7 @@ const buildDefaultConnection = (): NodeConnection => ({
   maxPeers: 50
 });
 
-const buildTestnetConnection = (): NodeConnection => ({
-  id: makeId(),
-  label: 'Testnet node',
-  mode: 'local',
-  participationRole: 'full_node',
-  wsUrl: `ws://127.0.0.1:${defaultRpcPort}`,
-  httpUrl: `http://127.0.0.1:${defaultRpcPort}`,
-  dev: false,
-  tmp: false,
-  basePath: '~/.hegemon-node-testnet',
-  rpcPort: defaultRpcPort,
-  p2pPort: defaultP2pPort,
-  mineThreads: defaultMineThreads,
-  miningIntent: false,
-  ciphertextDaRetentionBlocks: 0,
-  proofDaRetentionBlocks: 0,
-  daStoreCapacity: 1024,
-  rpcMethods: 'unsafe',
-  rpcCorsAll: false,
-  seeds: approvedSeeds,
-  maxPeers: 50
-});
-
-const buildDefaultConnections = () => [buildDefaultConnection(), buildTestnetConnection()];
+const buildDefaultConnections = () => [buildDefaultConnection()];
 
 const normalizeRpcControlPlane = (connection: NodeConnection): NodeConnection => {
   if (connection.mode !== 'local') {
@@ -1026,6 +1001,9 @@ const shouldAutoStartDefaultProfile = (connection: NodeConnection): boolean => {
   );
 };
 
+const findDefaultManagedConnection = (connections: NodeConnection[]) =>
+  connections.find((connection) => shouldAutoStartDefaultProfile(connection)) ?? null;
+
 export default function App() {
   const [connections, setConnections] = useState<NodeConnection[]>([]);
   const [activeConnectionId, setActiveConnectionId] = useState('');
@@ -1109,7 +1087,10 @@ export default function App() {
       try {
         const parsed = JSON.parse(storedConnections) as NodeConnection[];
         if (parsed.length) {
-          const normalized = parsed.map(normalizeConnection);
+          const normalizedStored = parsed.map(normalizeConnection);
+          const normalized = findDefaultManagedConnection(normalizedStored)
+            ? normalizedStored
+            : [buildDefaultConnection(), ...normalizedStored];
           setConnections(normalized);
           const storedActive = window.localStorage.getItem(activeConnectionKey);
           const storedWallet = window.localStorage.getItem(walletConnectionKey);
@@ -1353,6 +1334,7 @@ export default function App() {
   const activeDisplayIsSyncing = activeDisplayState.isSyncing;
   const activeHeightDelta = activeDisplayState.heightDelta;
   const activeHeightRelation = activeDisplayState.heightRelation;
+  const activeCanonicalStatus = activeDisplayState.canonicalStatus;
   const healthLabel = activeDisplayState.healthLabel;
   const healthTone = activeDisplayState.healthTone;
 
@@ -1466,6 +1448,7 @@ export default function App() {
             syncTargetHeight: null,
             pendingExtrinsics: null,
             peerList: null,
+            canonicalCheckpoint: null,
             supplyDigest: null,
             storage: null,
             telemetry: null,
@@ -1695,6 +1678,43 @@ export default function App() {
     autoStartAttemptedRef.current.add(activeConnection.id);
     void handleNodeStart({ automatic: true });
   }, [activeConnection, activeSummary?.reachable, nodeBusy, nodeTransition, nodeManagedStatus?.managed]);
+
+  useEffect(() => {
+    if (!activeConnection || activeSummary?.reachable !== false) {
+      return;
+    }
+    if (shouldAutoStartDefaultProfile(activeConnection)) {
+      return;
+    }
+    if (nodeBusy || nodeTransition || nodeManagedStatus?.managed) {
+      return;
+    }
+
+    const defaultManagedConnection = findDefaultManagedConnection(connections);
+    if (defaultManagedConnection) {
+      setActiveConnectionId(defaultManagedConnection.id);
+      if (!walletConnection || walletConnection.id === activeConnection.id) {
+        setWalletConnectionId(defaultManagedConnection.id);
+      }
+      return;
+    }
+
+    const fallback = buildDefaultConnection();
+    setConnections((prev) => [fallback, ...prev]);
+    setActiveConnectionId(fallback.id);
+    if (!walletConnectionId || walletConnectionId === activeConnection.id) {
+      setWalletConnectionId(fallback.id);
+    }
+  }, [
+    activeConnection,
+    activeSummary?.reachable,
+    connections,
+    nodeBusy,
+    nodeTransition,
+    nodeManagedStatus?.managed,
+    walletConnection,
+    walletConnectionId
+  ]);
 
   const handleNodeStop = async () => {
     if (!activeConnection || activeConnection.mode !== 'local') {
@@ -2429,10 +2449,16 @@ export default function App() {
   const syncStateLabel =
     nodeStartupPending
       ? 'Starting'
+      : activeCanonicalStatus === 'mismatch'
+        ? 'Forked from Hegemon testnet'
+        : activeCanonicalStatus === 'pending'
+          ? 'Checkpoint pending'
+          : activeCanonicalStatus === 'unavailable'
+            ? 'Checkpoint unavailable'
       : activeHeightRelation === 'syncing'
         ? `Syncing to ${formatNumber(activeDisplaySyncTargetHeight)}`
         : activeHeightRelation === 'aligned'
-          ? 'In sync with peer target'
+          ? 'In sync with Hegemon testnet'
           : activeHeightRelation === 'local_ahead'
             ? 'Local miner ahead'
             : activeHeightRelation === 'network_ahead'
@@ -2467,6 +2493,12 @@ export default function App() {
   const syncAlignmentLabel =
     nodeStartupPending
       ? 'Starting'
+      : activeCanonicalStatus === 'mismatch'
+        ? 'Fork mismatch'
+        : activeCanonicalStatus === 'pending'
+          ? 'Checkpoint pending'
+          : activeCanonicalStatus === 'unavailable'
+            ? 'Checkpoint unknown'
       : activeHeightRelation === 'syncing'
         ? `Syncing to ${formatNumber(activeDisplaySyncTargetHeight)}`
         : activeHeightRelation === 'aligned'
@@ -2476,10 +2508,17 @@ export default function App() {
             : activeHeightRelation === 'network_ahead'
               ? `Network ahead ${activeHeightDeltaAbsLabel}`
               : 'No live height';
-  const syncAlignmentTone: 'ok' | 'warn' | 'neutral' =
-    nodeStartupPending || activeHeightRelation === 'syncing' || activeHeightRelation === 'network_ahead'
+  const syncAlignmentTone: 'ok' | 'warn' | 'neutral' | 'error' =
+    activeCanonicalStatus === 'mismatch'
+      ? 'error'
+      : nodeStartupPending ||
+          activeCanonicalStatus === 'pending' ||
+          activeCanonicalStatus === 'unavailable' ||
+          activeHeightRelation === 'syncing' ||
+          activeHeightRelation === 'network_ahead'
       ? 'warn'
-      : activeHeightRelation === 'aligned' || activeHeightRelation === 'local_ahead'
+      : activeCanonicalStatus === 'verified' &&
+          (activeHeightRelation === 'aligned' || activeHeightRelation === 'local_ahead')
         ? 'ok'
         : 'neutral';
   const liveEnvironmentLabel = activeChainSpecLabel;
@@ -2506,23 +2545,39 @@ export default function App() {
     : nodeStartupPending
       ? `Opening ${formatEndpoint(activeConnection?.wsUrl)} and joining ${activeChainSpecLabel}. Wallet traffic stays on this laptop.`
       : 'Start the managed local node to join Hegemon with no SSH tunnel.';
-  const liveVerdictTone: 'ok' | 'warn' | 'neutral' =
-    nodeStartupPending ? 'warn' : activeNodeLive && activePeerCount !== null && activePeerCount > 0 ? 'ok' : activeNodeLive ? 'warn' : 'neutral';
+  const liveVerdictTone: 'ok' | 'warn' | 'neutral' | 'error' =
+    nodeStartupPending
+      ? 'warn'
+      : activeCanonicalStatus === 'mismatch'
+        ? 'error'
+        : activeNodeLive && activePeerCount !== null && activePeerCount > 0 && activeCanonicalStatus === 'verified'
+          ? 'ok'
+          : activeNodeLive
+            ? 'warn'
+            : 'neutral';
   const liveVerdictLabel =
     nodeStartupPending
       ? 'Local node is starting'
-      : activeNodeLive && activePeerCount !== null && activePeerCount > 0
-      ? 'Connected to Hegemon'
+      : activeCanonicalStatus === 'mismatch'
+      ? 'Wrong chain'
+      : activeNodeLive && activePeerCount !== null && activePeerCount > 0 && activeCanonicalStatus === 'verified'
+      ? 'Verified on Hegemon'
       : activeNodeLive
-        ? 'Node online, waiting for peers'
+        ? 'Node online, checking testnet'
         : 'Not connected';
   const liveVerdictDetail =
     nodeStartupPending
       ? 'The app is launching the managed 0.10 node and will switch to live telemetry automatically.'
+      : activeCanonicalStatus === 'mismatch'
+      ? activeSummary?.canonicalCheckpoint?.detail ?? 'This node is not on the canonical Hegemon testnet branch.'
+      : activeCanonicalStatus === 'pending'
+      ? activeSummary?.canonicalCheckpoint?.detail ?? 'The node has not reached the first Hegemon testnet checkpoint yet.'
+      : activeCanonicalStatus === 'unavailable'
+      ? activeSummary?.canonicalCheckpoint?.detail ?? 'Checkpoint status is not available from the selected node.'
       : activeNodeLive && activePeerCount !== null && activePeerCount > 0 && activeHeightRelation === 'local_ahead'
-      ? `Peer, seed, and genesis match; this miner is ${activeHeightDeltaAbsLabel} ahead of the latest peer target.`
+      ? `Canonical checkpoint verified; this miner is ${activeHeightDeltaAbsLabel} ahead of the latest peer target.`
       : activeNodeLive && activePeerCount !== null && activePeerCount > 0
-      ? 'Peer, seed, and genesis match the Hegemon 0.10 network.'
+      ? 'Canonical checkpoint, seed, and peer connection match the Hegemon testnet.'
       : activeNodeLive
         ? 'RPC is reachable; waiting for a P2P peer.'
         : 'Start the local node before syncing the wallet or sending funds.';
@@ -3079,7 +3134,15 @@ export default function App() {
           <details className="connection-evidence">
             <summary>
               <span>Connection evidence</span>
-              <strong>{firstActivePeer ? 'Peer, seed, and genesis verified' : 'Seed and genesis configured'}</strong>
+              <strong>
+                {activeCanonicalStatus === 'verified'
+                  ? 'Canonical checkpoint verified'
+                  : activeCanonicalStatus === 'mismatch'
+                    ? 'Fork mismatch'
+                    : firstActivePeer
+                      ? 'Peer connected; checkpoint pending'
+                      : 'Seed configured; no checkpoint yet'}
+              </strong>
             </summary>
             <div className="proof-stack" aria-label="Live connection evidence">
               <div className="proof-row">
@@ -3090,7 +3153,16 @@ export default function App() {
               <div className="proof-row">
                 <span>Seed</span>
                 <strong className="mono" title={activeSeedList}>{activeSeedList || 'N/A'}</strong>
-                <em>approved Hegemon 0.10 seed</em>
+                <em>approved Hegemon testnet seed</em>
+              </div>
+              <div className="proof-row">
+                <span>Checkpoint</span>
+                <strong className="mono" title={activeSummary?.canonicalCheckpoint?.actualHash ?? ''}>
+                  {activeSummary?.canonicalCheckpoint?.height
+                    ? `${formatNumber(activeSummary.canonicalCheckpoint.height)} · ${activeCanonicalStatus}`
+                    : activeCanonicalStatus}
+                </strong>
+                <em>{activeSummary?.canonicalCheckpoint?.detail ?? 'No checkpoint data yet'}</em>
               </div>
               <div className="proof-row">
                 <span>Peer</span>

--- a/hegemon-app/src/appGuards.ts
+++ b/hegemon-app/src/appGuards.ts
@@ -10,13 +10,14 @@ export type NodeDisplayState = {
   heightDelta: number | null;
   heightRelation: 'unknown' | 'syncing' | 'aligned' | 'local_ahead' | 'network_ahead';
   miningGateBlocked: boolean;
-  healthLabel: 'Unknown' | 'Offline' | 'Mining gated' | 'Syncing' | 'Healthy';
+  canonicalStatus: 'verified' | 'pending' | 'mismatch' | 'unavailable';
+  healthLabel: 'Unknown' | 'Offline' | 'Forked' | 'Mining gated' | 'Syncing' | 'Checking' | 'Healthy';
   healthTone: StatusTone;
 };
 
 export const legacyContactWarning = (contact: Contact) => {
   const descriptor = `${contact.name} ${contact.notes ?? ''} ${contact.protocolVersion ?? ''}`.toLowerCase();
-  if (/\b0\.9(?:\.1)?\b|hegemon-ovh|legacy/.test(descriptor)) {
+  if (/\b0\.9(?:\.1)?\b|legacy/.test(descriptor)) {
     return 'Legacy contact. Recreate or verify this recipient on Hegemon 0.10 before sending.';
   }
   return null;
@@ -46,6 +47,7 @@ export const computeNodeDisplayState = (summary: NodeSummary | null | undefined)
   const miningGateBlocked = Boolean(
     summary?.mining && summary.miningSyncGateOpen === false && !startupSummarySettling
   );
+  const canonicalStatus = summary?.canonicalCheckpoint?.status ?? 'unavailable';
   const heightDelta =
     typeof summary?.bestNumber === 'number' && typeof syncTargetHeight === 'number'
       ? summary.bestNumber - syncTargetHeight
@@ -65,17 +67,23 @@ export const computeNodeDisplayState = (summary: NodeSummary | null | undefined)
       ? 'Unknown'
       : !summary.reachable
         ? 'Offline'
-        : miningGateBlocked
+        : canonicalStatus === 'mismatch'
+          ? 'Forked'
+          : miningGateBlocked
           ? 'Mining gated'
           : isSyncing
             ? 'Syncing'
-            : 'Healthy';
+            : canonicalStatus === 'pending' || canonicalStatus === 'unavailable'
+              ? 'Checking'
+              : 'Healthy';
   const healthTone: StatusTone =
     !summary
       ? 'neutral'
       : !summary.reachable
         ? 'error'
-        : miningGateBlocked || isSyncing
+        : canonicalStatus === 'mismatch'
+          ? 'error'
+        : miningGateBlocked || isSyncing || canonicalStatus === 'pending' || canonicalStatus === 'unavailable'
           ? 'warn'
           : 'ok';
 
@@ -87,6 +95,7 @@ export const computeNodeDisplayState = (summary: NodeSummary | null | undefined)
     heightDelta,
     heightRelation,
     miningGateBlocked,
+    canonicalStatus,
     healthLabel,
     healthTone
   };

--- a/hegemon-app/src/types.ts
+++ b/hegemon-app/src/types.ts
@@ -85,6 +85,16 @@ export type NodePeerSnapshot = {
   protocols?: number[];
 };
 
+export type CanonicalCheckpointStatus = {
+  network: string;
+  seed: string;
+  status: 'verified' | 'pending' | 'mismatch' | 'unavailable';
+  height: number | null;
+  expectedHash: string | null;
+  actualHash: string | null;
+  detail: string;
+};
+
 export type NodeSummary = {
   connectionId: string;
   label: string;
@@ -109,6 +119,7 @@ export type NodeSummary = {
   syncTargetHeight: number | null;
   pendingExtrinsics: number | null;
   peerList: NodePeerSnapshot[] | null;
+  canonicalCheckpoint: CanonicalCheckpointStatus | null;
   supplyDigest: string | null;
   storage: NodeStorageFootprint | null;
   telemetry: NodeTelemetry | null;

--- a/network/src/peer_manager.rs
+++ b/network/src/peer_manager.rs
@@ -19,7 +19,7 @@ pub type PeerSessionId = u64;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AddPeerResult {
     Accepted,
-    Replaced(PeerSessionId),
+    Duplicate(PeerSessionId),
     RejectedAtCapacity,
 }
 
@@ -79,17 +79,9 @@ impl PeerManager {
         if dialable_addr {
             self.record_addresses(peer_id, [addr]);
         }
-        if let std::collections::hash_map::Entry::Occupied(mut entry) = self.peers.entry(peer_id) {
-            let old_session = entry.get().session_id;
-            entry.insert(PeerEntry {
-                peer_id,
-                tx,
-                addr,
-                session_id,
-                last_seen: Instant::now(),
-                score: 0,
-            });
-            return AddPeerResult::Replaced(old_session);
+        if let Some(entry) = self.peers.get_mut(&peer_id) {
+            entry.last_seen = Instant::now();
+            return AddPeerResult::Duplicate(entry.session_id);
         }
 
         if self.max_peers > 0 && self.peers.len() >= self.max_peers {
@@ -496,7 +488,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn replacing_same_peer_closes_old_session_and_ignores_stale_remove() {
+    async fn duplicate_same_peer_keeps_existing_session_and_rejects_new_session() {
         let mut manager = PeerManager::new(2);
         let peer: PeerId = [8u8; 32];
         let old_addr: SocketAddr = "127.0.0.1:9501".parse().unwrap();
@@ -510,20 +502,19 @@ mod tests {
         );
         assert_eq!(
             manager.try_add_peer(peer, new_addr, new_tx, 202, true),
-            AddPeerResult::Replaced(101)
+            AddPeerResult::Duplicate(101)
         );
-        assert!(old_rx.recv().await.is_none());
-        assert!(!manager.is_active_session(&peer, 101));
-        assert!(manager.is_active_session(&peer, 202));
-        assert_eq!(manager.remove_peer_session(&peer, 101), None);
-        assert!(manager.is_active_session(&peer, 202));
+        assert!(manager.is_active_session(&peer, 101));
+        assert!(!manager.is_active_session(&peer, 202));
+        assert!(new_rx.recv().await.is_none());
 
         manager.send_to(&peer, WireMessage::Pong).await;
         assert!(matches!(
-            new_rx.recv().await.map(|queued| queued.msg),
+            old_rx.recv().await.map(|queued| queued.msg),
             Some(WireMessage::Pong)
         ));
-        assert_eq!(manager.remove_peer_session(&peer, 202), Some(new_addr));
+        assert_eq!(manager.remove_peer_session(&peer, 202), None);
+        assert_eq!(manager.remove_peer_session(&peer, 101), Some(old_addr));
         assert_eq!(manager.peer_count(), 0);
     }
 }

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -254,6 +254,12 @@ enum P2PCommand {
     InboundHandshakeFailed,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PeerRunOutcome {
+    AdmissionRejected,
+    Disconnected,
+}
+
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(90);
 const RECONNECT_BASE: Duration = Duration::from_secs(2);
@@ -270,7 +276,7 @@ const OPPORTUNISTIC_BATCH: usize = 4;
 const RECENT_RECONNECT_LIMIT: usize = 5;
 const SEEN_GOSSIP_LIMIT: usize = 4096;
 const MAX_LEARNED_ADDRESSES: usize = 1024;
-const PROTOCOL_CHANNEL_CAPACITY: usize = 128;
+const PROTOCOL_CHANNEL_CAPACITY: usize = 1024;
 const MAX_PROTOCOL_OUTBOUND_QUEUE_BYTES: usize = 64 * 1024 * 1024;
 const MAX_PROTOCOL_INBOUND_QUEUE_BYTES: usize = 64 * 1024 * 1024;
 const MAX_P2P_COMMAND_QUEUE_BYTES: usize = 64 * 1024 * 1024;
@@ -543,6 +549,15 @@ impl P2PService {
                                 pending_inbound_handshakes =
                                     pending_inbound_handshakes.saturating_sub(1);
                             }
+                            if peer_id == self.identity.peer_id() {
+                                warn!(
+                                    %addr,
+                                    session_id,
+                                    "rejecting self peer connection"
+                                );
+                                let _ = admit.send(false);
+                                continue;
+                            }
                             info!("peer connected: {} ({:?})", addr, peer_id);
                             let admission = self.peer_manager.try_add_peer(
                                 peer_id,
@@ -555,14 +570,15 @@ impl P2PService {
                                 AddPeerResult::Accepted => {
                                     let _ = admit.send(true);
                                 }
-                                AddPeerResult::Replaced(old_session) => {
+                                AddPeerResult::Duplicate(active_session) => {
                                     warn!(
                                         ?peer_id,
-                                        old_session,
-                                        new_session = session_id,
-                                        "replaced existing peer session"
+                                        active_session,
+                                        rejected_session = session_id,
+                                        "rejecting duplicate peer session"
                                     );
-                                    let _ = admit.send(true);
+                                    let _ = admit.send(false);
+                                    continue;
                                 }
                                 AddPeerResult::RejectedAtCapacity => {
                                     warn!(
@@ -778,8 +794,12 @@ impl P2PService {
                             .await
                         {
                             Ok(Ok(peer_id)) => {
+                                if peer_id == identity.peer_id() {
+                                    warn!(%addr, "rejecting persistent self dial");
+                                    break;
+                                }
                                 let session_id = next_peer_session_id();
-                                Self::run_peer_loop(
+                                let outcome = Self::run_peer_loop(
                                     connection,
                                     addr,
                                     peer_id,
@@ -789,7 +809,10 @@ impl P2PService {
                                     inbound_message_budget.clone(),
                                 )
                                 .await;
-                                backoff = RECONNECT_BASE;
+                                backoff = match outcome {
+                                    PeerRunOutcome::Disconnected => RECONNECT_BASE,
+                                    PeerRunOutcome::AdmissionRejected => RECONNECT_MAX,
+                                };
                             }
                             Ok(Err(e)) => {
                                 warn!("handshake failed with {}: {}", addr, e);
@@ -824,7 +847,7 @@ impl P2PService {
                 Ok(Ok(peer_id)) => {
                     drop(permit);
                     let session_id = next_peer_session_id();
-                    Self::run_peer_loop(
+                    let _ = Self::run_peer_loop(
                         connection,
                         addr,
                         peer_id,
@@ -857,7 +880,7 @@ impl P2PService {
         cmd_tx: mpsc::Sender<P2PCommand>,
         inbound: bool,
         inbound_message_budget: ByteBudget,
-    ) {
+    ) -> PeerRunOutcome {
         let (tx, mut rx) = mpsc::channel::<QueuedWireMessage>(100);
         let (admit, admitted) = oneshot::channel();
         if cmd_tx
@@ -872,11 +895,11 @@ impl P2PService {
             .await
             .is_err()
         {
-            return;
+            return PeerRunOutcome::AdmissionRejected;
         }
 
         if !matches!(admitted.await, Ok(true)) {
-            return;
+            return PeerRunOutcome::AdmissionRejected;
         }
 
         loop {
@@ -933,6 +956,7 @@ impl P2PService {
                 inbound,
             })
             .await;
+        PeerRunOutcome::Disconnected
     }
 
     fn inbound_handshake_backlog_limit(&self) -> usize {
@@ -1544,8 +1568,12 @@ impl P2PService {
                         .await
                     {
                         Ok(Ok(peer_id)) => {
+                            if peer_id == identity.peer_id() {
+                                warn!(%addr, "rejecting opportunistic self dial");
+                                return;
+                            }
                             let session_id = next_peer_session_id();
-                            Self::run_peer_loop(
+                            let _ = Self::run_peer_loop(
                                 connection,
                                 addr,
                                 peer_id,

--- a/node/README.md
+++ b/node/README.md
@@ -15,10 +15,10 @@ HEGEMON_MINE=1 ./target/release/hegemon-node --dev --tmp
 When joining a shared network, set the approved seed list before starting the node:
 
 ```bash
-export HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333"
+export HEGEMON_SEEDS="hegemon.pauli.group:30333"
 ```
 
-Every miner should use the same `HEGEMON_SEEDS` list to avoid accidental forks. Also enable time sync (`ntpd`, `chronyd`, or the platform equivalent) because PoW timestamps are rejected if they exceed the future-skew bound.
+Every miner should use the same approved `HEGEMON_SEEDS` list to avoid accidental forks. Also enable time sync (`ntpd`, `chronyd`, or the platform equivalent) because PoW timestamps are rejected if they exceed the future-skew bound.
 
 ## RPC surface
 

--- a/node/src/native/mod.rs
+++ b/node/src/native/mod.rs
@@ -113,17 +113,17 @@ const MAX_NATIVE_MEMPOOL_ACTIONS: usize = 10_000;
 const MAX_PREPARED_MINING_WORKS: usize = 128;
 const MAX_PREPARED_CANDIDATE_ACTIONS: usize = 128;
 const NATIVE_SYNC_PROTOCOL_ID: ProtocolId = 0x4847_4e53;
-const MAX_NATIVE_SYNC_RESPONSE_BLOCKS: u64 = 512;
+const MAX_NATIVE_SYNC_RESPONSE_BLOCKS: u64 = 128;
 const MAX_NATIVE_SYNC_RESPONSE_BLOCKS_USIZE: usize = MAX_NATIVE_SYNC_RESPONSE_BLOCKS as usize;
-const NATIVE_ANNOUNCE_INTERVAL: u64 = 16;
-const NATIVE_SYNC_BEST_ANNOUNCE_INTERVAL: Duration = Duration::from_secs(10);
+const NATIVE_SYNC_BEST_ANNOUNCE_INTERVAL: Duration = Duration::from_secs(2);
 const NATIVE_SYNC_PENDING_ACTION_REBROADCAST_INTERVAL: Duration = Duration::from_secs(5);
 const NATIVE_SYNC_PENDING_ACTION_REBROADCAST_LIMIT: usize = 32;
 const NATIVE_SYNC_REQUEST_RATE_WINDOW: Duration = Duration::from_secs(10);
+const NATIVE_SYNC_REQUEST_RETRY_AFTER: Duration = Duration::from_secs(12);
 const MAX_NATIVE_SYNC_REQUESTS_PER_WINDOW: u32 = 4;
 const NATIVE_SYNC_REQUEST_RATE_LIMIT_STATE_TTL: Duration = Duration::from_secs(10 * 60);
 const MAX_NATIVE_SYNC_REQUEST_RATE_LIMIT_PEERS: usize = 4096;
-const NATIVE_SYNC_REORG_BACKFILL_BLOCKS: u64 = 128;
+const NATIVE_SYNC_REORG_BACKFILL_BLOCKS: u64 = 32;
 const NATIVE_SYNC_BOOTSTRAP_BACKFILL_FLOOR: u64 = 1;
 const APPROVED_PUBLIC_JOIN_SEEDS: &str = "hegemon.pauli.group:30333";
 const AES_GCM_TAG_BYTES: usize = 16;
@@ -296,6 +296,41 @@ impl NativeConfig {
 
     fn permits_empty_seed_authoring(&self) -> bool {
         self.dev || self.bootstrap_mining_authoring
+    }
+
+    fn public_testnet_profile(&self) -> bool {
+        if !self.dev || self.tmp {
+            return false;
+        }
+        self.seeds
+            .iter()
+            .any(|seed| seed.trim().eq_ignore_ascii_case(APPROVED_PUBLIC_JOIN_SEEDS))
+            || (self.bootstrap_mining_authoring
+                && self
+                    .base_path
+                    .to_string_lossy()
+                    .to_ascii_lowercase()
+                    .contains("testnet"))
+    }
+
+    fn chain_spec_id(&self) -> &'static str {
+        if self.public_testnet_profile() {
+            "hegemon-native-testnet"
+        } else if self.dev {
+            "hegemon-native-dev"
+        } else {
+            "hegemon-native"
+        }
+    }
+
+    fn chain_type(&self) -> &'static str {
+        if self.public_testnet_profile() {
+            "testnet"
+        } else if self.dev {
+            "dev"
+        } else {
+            "live"
+        }
     }
 }
 
@@ -537,6 +572,12 @@ struct NativeSyncRequestRateState {
     requests: u32,
 }
 
+#[derive(Clone, Debug)]
+struct NativeOutboundSyncRequest {
+    range: NativeSyncRange,
+    requested_at: Instant,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct NativeMiningSyncEvidenceInput {
     verified_new_progress: bool,
@@ -616,12 +657,12 @@ fn native_mining_sync_observed_peer_height(input: NativeMiningSyncEvidenceInput)
         return None;
     }
     if input.verified_new_progress {
-        return Some(input.local_best_height);
+        return Some(input.peer_best_height);
     }
     if input.verified_known_at_or_below_local_best
         && input.peer_best_height <= input.local_best_height
     {
-        return Some(input.peer_best_height);
+        return Some(input.local_best_height);
     }
     None
 }
@@ -2982,11 +3023,16 @@ pub struct NativeNode {
     pending_action_rebroadcast_cursor: AtomicU64,
     sync_target_height: AtomicU64,
     sync_target_observed: AtomicBool,
+    sync_target_peer: Mutex<Option<PeerId>>,
+    sync_target_hash: Mutex<Option<[u8; 32]>>,
     mining_sync_gate_open: AtomicBool,
+    sync_import_in_flight: AtomicBool,
     network_peer_count: Arc<AtomicUsize>,
     network_local_peer_id: Arc<StdRwLock<Option<PeerId>>>,
     network_peer_snapshot: Arc<StdRwLock<Vec<ConnectedPeerSnapshot>>>,
     sync_request_rate_limits: Mutex<BTreeMap<PeerId, NativeSyncRequestRateState>>,
+    sync_response_in_flight_peers: Mutex<BTreeSet<PeerId>>,
+    outbound_sync_requests: Mutex<BTreeMap<PeerId, NativeOutboundSyncRequest>>,
     mining_tasks: Mutex<Vec<JoinHandle<()>>>,
     sync_tx: Mutex<Option<ProtocolSender>>,
     miner_identity: NativeMinerIdentity,
@@ -3062,8 +3108,8 @@ impl NativeNode {
             "native Hegemon node storage reload completed"
         );
 
-        let initial_mining_sync_gate_open =
-            config.seeds.is_empty() && config.permits_empty_seed_authoring();
+        let initial_mining_sync_gate_open = config.bootstrap_mining_authoring
+            || (config.seeds.is_empty() && config.permits_empty_seed_authoring());
         let node = Arc::new(Self {
             config,
             db,
@@ -3089,11 +3135,16 @@ impl NativeNode {
             pending_action_rebroadcast_cursor: AtomicU64::new(0),
             sync_target_height: AtomicU64::new(0),
             sync_target_observed: AtomicBool::new(initial_mining_sync_gate_open),
+            sync_target_peer: Mutex::new(None),
+            sync_target_hash: Mutex::new(None),
             mining_sync_gate_open: AtomicBool::new(initial_mining_sync_gate_open),
+            sync_import_in_flight: AtomicBool::new(false),
             network_peer_count: Arc::new(AtomicUsize::new(0)),
             network_local_peer_id: Arc::new(StdRwLock::new(None)),
             network_peer_snapshot: Arc::new(StdRwLock::new(Vec::new())),
             sync_request_rate_limits: Mutex::new(BTreeMap::new()),
+            sync_response_in_flight_peers: Mutex::new(BTreeSet::new()),
+            outbound_sync_requests: Mutex::new(BTreeMap::new()),
             mining_tasks: Mutex::new(Vec::new()),
             sync_tx: Mutex::new(None),
             miner_identity,
@@ -3140,8 +3191,91 @@ impl NativeNode {
         self.refresh_mining_sync_gate();
     }
 
+    fn observe_pending_sync_peer_height(&self, peer_best_height: u64) {
+        self.observe_pending_sync_peer_tip(None, peer_best_height, None);
+    }
+
+    fn observe_pending_sync_peer_tip(
+        &self,
+        peer_id: Option<PeerId>,
+        peer_best_height: u64,
+        peer_best_hash: Option<[u8; 32]>,
+    ) {
+        let best = self.best_meta();
+        let unresolved_equal_height_tip =
+            peer_best_height == best.height && peer_best_hash.is_some_and(|hash| hash != best.hash);
+        if peer_best_height < best.height
+            || (peer_best_height == best.height && !unresolved_equal_height_tip)
+        {
+            return;
+        }
+        self.sync_target_observed.store(true, Ordering::SeqCst);
+        self.sync_target_height
+            .fetch_max(peer_best_height, Ordering::Relaxed);
+        if let Some(peer_id) = peer_id {
+            *self.sync_target_peer.lock() = Some(peer_id);
+        }
+        if let Some(peer_best_hash) = peer_best_hash {
+            *self.sync_target_hash.lock() = Some(peer_best_hash);
+        }
+        self.mining_sync_gate_open.store(false, Ordering::SeqCst);
+    }
+
     fn has_verified_header_hash(&self, hash: &[u8; 32]) -> Result<bool> {
         Ok(self.header_by_hash(hash)?.is_some())
+    }
+
+    fn begin_sync_import(&self) -> bool {
+        self.sync_import_in_flight
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    fn end_sync_import(&self) {
+        self.sync_import_in_flight.store(false, Ordering::Release);
+    }
+
+    fn sync_import_in_flight(&self) -> bool {
+        self.sync_import_in_flight.load(Ordering::Acquire)
+    }
+
+    fn begin_sync_response_for_peer(&self, peer_id: PeerId) -> bool {
+        self.sync_response_in_flight_peers.lock().insert(peer_id)
+    }
+
+    fn end_sync_response_for_peer(&self, peer_id: PeerId) {
+        self.sync_response_in_flight_peers.lock().remove(&peer_id);
+    }
+
+    fn begin_outbound_sync_request(&self, peer_id: Option<PeerId>, range: NativeSyncRange) -> bool {
+        let Some(peer_id) = peer_id else {
+            return true;
+        };
+        let now = Instant::now();
+        let mut requests = self.outbound_sync_requests.lock();
+        requests.retain(|_, request| {
+            now.saturating_duration_since(request.requested_at) <= NATIVE_SYNC_REQUEST_RETRY_AFTER
+        });
+        if let Some(request) = requests.get(&peer_id) {
+            if request.range == range
+                && now.saturating_duration_since(request.requested_at)
+                    < NATIVE_SYNC_REQUEST_RETRY_AFTER
+            {
+                return false;
+            }
+        }
+        requests.insert(
+            peer_id,
+            NativeOutboundSyncRequest {
+                range,
+                requested_at: now,
+            },
+        );
+        true
+    }
+
+    fn complete_outbound_sync_request(&self, peer_id: PeerId) {
+        self.outbound_sync_requests.lock().remove(&peer_id);
     }
 
     fn admit_sync_request_from_peer(
@@ -3238,8 +3372,40 @@ impl NativeNode {
             return;
         }
         let target = self.sync_target_height.load(Ordering::Relaxed);
-        self.mining_sync_gate_open
-            .store(self.best_meta().height >= target, Ordering::SeqCst);
+        let resolved = self.sync_target_resolved(target);
+        self.mining_sync_gate_open.store(resolved, Ordering::SeqCst);
+        if resolved {
+            *self.sync_target_peer.lock() = None;
+        }
+    }
+
+    fn sync_target_resolved(&self, target: u64) -> bool {
+        let best = self.best_meta();
+        if best.height < target {
+            return false;
+        }
+        let Some(target_hash) = *self.sync_target_hash.lock() else {
+            return true;
+        };
+        if best.hash == target_hash {
+            return true;
+        }
+        if best.height > target {
+            return true;
+        }
+        match self.header_by_hash(&target_hash) {
+            Ok(Some(target_meta)) => !native_meta_better_than(&target_meta, &best),
+            Ok(None) => false,
+            Err(err) => {
+                warn!(
+                    target,
+                    target_hash = %hex32(&target_hash),
+                    error = %err,
+                    "failed to resolve native sync target hash"
+                );
+                false
+            }
+        }
     }
 
     fn mining_sync_gate_allows_work(&self) -> bool {
@@ -3254,10 +3420,11 @@ impl NativeNode {
     fn sync_status_fields(&self) -> (bool, u64) {
         let target = self.sync_target_height.load(Ordering::Relaxed);
         let observed = self.sync_target_observed.load(Ordering::SeqCst);
+        let target_resolved = self.sync_target_resolved(target);
         let syncing = !self.config.seeds.is_empty()
             && (!observed
                 || !self.mining_sync_gate_open.load(Ordering::SeqCst)
-                || (target > 0 && self.best_meta().height < target));
+                || !target_resolved);
         (syncing, target)
     }
 
@@ -4049,9 +4216,6 @@ impl NativeNode {
     }
 
     fn broadcast_block_announce(&self, meta: &NativeBlockMeta) {
-        if meta.height > 1 && !meta.height.is_multiple_of(NATIVE_ANNOUNCE_INTERVAL) {
-            return;
-        }
         self.last_announce_height
             .store(meta.height, Ordering::Relaxed);
         let Some(sync_tx) = self.sync_tx.lock().clone() else {
@@ -4074,6 +4238,12 @@ impl NativeNode {
         };
         if let Err(err) = sync_tx.try_send(message) {
             debug!(error = %err, "failed to queue native block announce");
+        } else {
+            info!(
+                height = meta.height,
+                hash = %hex32(&meta.hash),
+                "queued native block announce"
+            );
         }
     }
 
@@ -5185,9 +5355,9 @@ impl NativeNode {
     fn node_config_snapshot(&self, policy: RpcMethodPolicy) -> Value {
         if policy != RpcMethodPolicy::Unsafe {
             return json!({
-                "chainSpecId": if self.config.dev { "hegemon-native-dev" } else { "hegemon-native" },
+                "chainSpecId": self.config.chain_spec_id(),
                 "chainSpecName": "Hegemon",
-                "chainType": if self.config.dev { "dev" } else { "live" },
+                "chainType": self.config.chain_type(),
                 "rpcMethods": self.config.rpc_methods,
                 "redacted": true,
             });
@@ -5195,9 +5365,9 @@ impl NativeNode {
 
         json!({
             "nodeName": self.config.node_name,
-            "chainSpecId": if self.config.dev { "hegemon-native-dev" } else { "hegemon-native" },
+            "chainSpecId": self.config.chain_spec_id(),
             "chainSpecName": "Hegemon",
-            "chainType": if self.config.dev { "dev" } else { "live" },
+            "chainType": self.config.chain_type(),
             "basePath": self.config.base_path.display().to_string(),
             "p2pListenAddr": self.config.p2p_listen_addr,
             "rpcListenAddr": self.config.rpc_addr.to_string(),
@@ -5985,6 +6155,7 @@ async fn native_sync_loop(node: Arc<NativeNode>, mut handle: ProtocolHandle) {
             maybe_msg = handle.recv() => maybe_msg,
             _ = best_announce.tick() => {
                 queue_native_best_sync_announce(&node, &sync_tx);
+                queue_missing_blocks_from_sync_target(&node, &sync_tx);
                 continue;
             }
             _ = pending_rebroadcast.tick() => {
@@ -6048,7 +6219,14 @@ async fn native_sync_loop(node: Arc<NativeNode>, mut handle: ProtocolHandle) {
                         {
                             node.observe_verified_sync_peer_height(observed_height);
                         }
-                        request_missing_blocks(&node, &handle, peer_id, announced_height).await;
+                        request_missing_blocks(
+                            &node,
+                            &handle,
+                            peer_id,
+                            announced_height,
+                            Some(meta.hash),
+                        )
+                        .await;
                     }
                     Err(err) => {
                         warn!(
@@ -6084,34 +6262,53 @@ async fn native_sync_loop(node: Arc<NativeNode>, mut handle: ProtocolHandle) {
                     );
                     continue;
                 }
-                let best_height = node.best_meta().height;
-                let node = Arc::clone(&node);
-                let blocks = match tokio::task::spawn_blocking(move || {
-                    node.block_range(from_height, to_height)
-                })
-                .await
-                {
-                    Ok(Ok(blocks)) => blocks,
-                    Ok(Err(err)) => {
-                        warn!(
-                            from_height,
-                            to_height,
-                            error = %err,
-                            "failed to load native sync block range"
-                        );
-                        continue;
+                if !node.begin_sync_response_for_peer(peer_id) {
+                    debug!(
+                        from_height,
+                        to_height,
+                        peer = %hex32(&peer_id),
+                        "skipping duplicate native sync response while peer has a response in flight"
+                    );
+                    continue;
+                }
+                let range_node = Arc::clone(&node);
+                let response_node = Arc::clone(&node);
+                let response_tx = sync_tx.clone();
+                tokio::spawn(async move {
+                    match tokio::task::spawn_blocking(move || {
+                        range_node.block_range(from_height, to_height)
+                    })
+                    .await
+                    {
+                        Ok(Ok(blocks)) => {
+                            let best_height = response_node.best_meta().height;
+                            send_sync_response_with_sender(
+                                &response_tx,
+                                peer_id,
+                                best_height,
+                                blocks,
+                            )
+                            .await;
+                        }
+                        Ok(Err(err)) => {
+                            warn!(
+                                from_height,
+                                to_height,
+                                error = %err,
+                                "failed to load native sync block range"
+                            );
+                        }
+                        Err(err) => {
+                            warn!(
+                                from_height,
+                                to_height,
+                                error = %err,
+                                "native sync block range worker failed"
+                            );
+                        }
                     }
-                    Err(err) => {
-                        warn!(
-                            from_height,
-                            to_height,
-                            error = %err,
-                            "native sync block range worker failed"
-                        );
-                        continue;
-                    }
-                };
-                send_sync_response(&handle, peer_id, best_height, blocks).await;
+                    response_node.end_sync_response_for_peer(peer_id);
+                });
             }
             NativeSyncMessage::Response {
                 best_height,
@@ -6123,6 +6320,7 @@ async fn native_sync_loop(node: Arc<NativeNode>, mut handle: ProtocolHandle) {
                     block_count = blocks.len(),
                     "received native sync response"
                 );
+                node.complete_outbound_sync_request(peer_id);
                 if let Err(rejection) = admit_and_sort_native_sync_response_blocks(
                     &mut blocks,
                     MAX_NATIVE_SYNC_RESPONSE_BLOCKS_USIZE,
@@ -6135,15 +6333,39 @@ async fn native_sync_loop(node: Arc<NativeNode>, mut handle: ProtocolHandle) {
                     );
                     continue;
                 }
+                if native_sync_response_stale_for_local_tip(&node, best_height, &blocks) {
+                    debug!(
+                        peer = %hex32(&peer_id),
+                        best_height,
+                        block_count = blocks.len(),
+                        local_height = node.best_meta().height,
+                        "dropping stale native sync response"
+                    );
+                    continue;
+                }
+                node.observe_pending_sync_peer_height(best_height);
+                if !node.begin_sync_import() {
+                    debug!(
+                        peer = %hex32(&peer_id),
+                        best_height,
+                        block_count = blocks.len(),
+                        "deferring native sync response while another import is active"
+                    );
+                    continue;
+                }
                 let progress = NativeSyncResponseImportProgress::new(blocks.len());
                 let import_node = Arc::clone(&node);
                 let report = match tokio::task::spawn_blocking(move || {
-                    import_native_sync_response_blocks(&import_node, blocks, progress)
+                    import_native_sync_response_blocks(&import_node, blocks, best_height, progress)
                 })
                 .await
                 {
-                    Ok(report) => report,
+                    Ok(report) => {
+                        node.end_sync_import();
+                        report
+                    }
                     Err(err) => {
+                        node.end_sync_import();
                         warn!(error = %err, "native sync import worker failed");
                         continue;
                     }
@@ -6180,8 +6402,9 @@ async fn native_sync_loop(node: Arc<NativeNode>, mut handle: ProtocolHandle) {
                     );
                 }
                 if progress.should_request_more(local_best_height, best_height) {
-                    request_missing_blocks(&node, &handle, peer_id, best_height).await;
+                    request_missing_blocks(&node, &handle, peer_id, best_height, None).await;
                 } else {
+                    queue_missing_blocks_from_sync_target(&node, &sync_tx);
                     node.refresh_mining_sync_gate();
                 }
             }
@@ -6255,13 +6478,39 @@ struct NativeSyncImportReport {
 fn import_native_sync_response_blocks(
     node: &NativeNode,
     blocks: Vec<NativeBlockMeta>,
+    peer_best_height: u64,
     mut progress: NativeSyncResponseImportProgress,
 ) -> NativeSyncImportReport {
+    if let Some(report) =
+        import_native_sync_response_winning_branch(node, &blocks, peer_best_height, &mut progress)
+    {
+        return report;
+    }
+
     let mut failure = None;
     for meta in blocks {
+        match skip_stale_nonwinning_sync_block(node, &meta, peer_best_height) {
+            Ok(true) => {
+                progress.record(NativeSyncResponseImportOutcome::AlreadyKnown);
+                continue;
+            }
+            Ok(false) => {}
+            Err(err) => {
+                progress.record(NativeSyncResponseImportOutcome::Error);
+                failure = Some(NativeSyncImportFailure {
+                    height: meta.height,
+                    hash: meta.hash,
+                    error: err.to_string(),
+                });
+                break;
+            }
+        }
         match node.import_announced_block(meta.clone()) {
             Ok(true) => {
                 progress.record(NativeSyncResponseImportOutcome::Imported);
+                if progress.imported_blocks == 1 {
+                    node.observe_verified_sync_peer_height(peer_best_height);
+                }
             }
             Ok(false) => {
                 progress.record(NativeSyncResponseImportOutcome::AlreadyKnown);
@@ -6278,6 +6527,188 @@ fn import_native_sync_response_blocks(
         }
     }
     NativeSyncImportReport { progress, failure }
+}
+
+fn import_native_sync_response_winning_branch(
+    node: &NativeNode,
+    blocks: &[NativeBlockMeta],
+    peer_best_height: u64,
+    progress: &mut NativeSyncResponseImportProgress,
+) -> Option<NativeSyncImportReport> {
+    let response_tip = blocks.last()?;
+    let local_best = node.best_meta();
+    if peer_best_height <= local_best.height || !native_meta_better_than(response_tip, &local_best)
+    {
+        return None;
+    }
+
+    let mut first_unknown = 0usize;
+    while first_unknown < blocks.len() {
+        match node.has_verified_header_hash(&blocks[first_unknown].hash) {
+            Ok(true) => {
+                progress.record(NativeSyncResponseImportOutcome::AlreadyKnown);
+                first_unknown += 1;
+            }
+            Ok(false) => break,
+            Err(err) => {
+                progress.record(NativeSyncResponseImportOutcome::Error);
+                return Some(NativeSyncImportReport {
+                    progress: *progress,
+                    failure: Some(NativeSyncImportFailure {
+                        height: blocks[first_unknown].height,
+                        hash: blocks[first_unknown].hash,
+                        error: err.to_string(),
+                    }),
+                });
+            }
+        }
+    }
+
+    let new_chain = if first_unknown == blocks.len() {
+        match node.chain_to_hash(response_tip.hash) {
+            Ok(chain) => chain,
+            Err(err) => {
+                progress.record(NativeSyncResponseImportOutcome::Error);
+                return Some(NativeSyncImportReport {
+                    progress: *progress,
+                    failure: Some(NativeSyncImportFailure {
+                        height: response_tip.height,
+                        hash: response_tip.hash,
+                        error: err.to_string(),
+                    }),
+                });
+            }
+        }
+    } else {
+        let anchor_hash = if first_unknown == 0 {
+            blocks[first_unknown].parent_hash
+        } else {
+            blocks[first_unknown - 1].hash
+        };
+        let _anchor = (match node.header_by_hash(&anchor_hash) {
+            Ok(anchor) => anchor,
+            Err(err) => {
+                progress.record(NativeSyncResponseImportOutcome::Error);
+                return Some(NativeSyncImportReport {
+                    progress: *progress,
+                    failure: Some(NativeSyncImportFailure {
+                        height: blocks[first_unknown].height,
+                        hash: blocks[first_unknown].hash,
+                        error: err.to_string(),
+                    }),
+                });
+            }
+        })?;
+        let mut chain = match node.chain_to_hash(anchor_hash) {
+            Ok(chain) => chain,
+            Err(err) => {
+                progress.record(NativeSyncResponseImportOutcome::Error);
+                return Some(NativeSyncImportReport {
+                    progress: *progress,
+                    failure: Some(NativeSyncImportFailure {
+                        height: blocks[first_unknown].height,
+                        hash: blocks[first_unknown].hash,
+                        error: err.to_string(),
+                    }),
+                });
+            }
+        };
+        chain.extend(blocks[first_unknown..].iter().cloned());
+        chain
+    };
+
+    let mut state = node.state.write();
+    if !native_meta_better_than(
+        new_chain.last().expect("sync response branch has tip"),
+        &state.best,
+    ) {
+        return None;
+    }
+    let previous_height = state.best.height;
+    let new_tip = new_chain
+        .last()
+        .expect("sync response branch has tip")
+        .clone();
+    match node.reorganize_chain_to_best_locked(&mut state, new_chain) {
+        Ok(()) => {
+            let imported = if first_unknown == blocks.len() {
+                1
+            } else {
+                blocks.len().saturating_sub(first_unknown)
+            };
+            progress.attempted_blocks = progress.response_block_count;
+            progress.imported_blocks = progress
+                .imported_blocks
+                .saturating_add(u64::try_from(imported).unwrap_or(u64::MAX));
+            info!(
+                imported,
+                previous_height,
+                best_height = new_tip.height,
+                peer_best_height,
+                "imported native sync response by batch reorg"
+            );
+            Some(NativeSyncImportReport {
+                progress: *progress,
+                failure: None,
+            })
+        }
+        Err(err) => {
+            progress.record(NativeSyncResponseImportOutcome::Error);
+            Some(NativeSyncImportReport {
+                progress: *progress,
+                failure: Some(NativeSyncImportFailure {
+                    height: new_tip.height,
+                    hash: new_tip.hash,
+                    error: err.to_string(),
+                }),
+            })
+        }
+    }
+}
+
+fn skip_stale_nonwinning_sync_block(
+    node: &NativeNode,
+    meta: &NativeBlockMeta,
+    peer_best_height: u64,
+) -> Result<bool> {
+    let local_best = node.best_meta();
+    if peer_best_height > local_best.height {
+        return Ok(false);
+    }
+    if meta.height > local_best.height {
+        return Ok(false);
+    }
+    if node.has_verified_header_hash(&meta.hash)? {
+        return Ok(false);
+    }
+    Ok(!native_meta_better_than(meta, &local_best))
+}
+
+fn native_sync_response_stale_for_local_tip(
+    node: &NativeNode,
+    peer_best_height: u64,
+    blocks: &[NativeBlockMeta],
+) -> bool {
+    let local_best = node.best_meta();
+    if peer_best_height > local_best.height {
+        return false;
+    }
+    let Some(response_tip) = blocks.last() else {
+        return true;
+    };
+    if response_tip.height > local_best.height {
+        return false;
+    }
+    if response_tip.hash == local_best.hash {
+        return true;
+    }
+    if native_meta_better_than(response_tip, &local_best) {
+        return false;
+    }
+    match node.has_verified_header_hash(&response_tip.hash) {
+        Ok(true) => true,
+        Ok(false) | Err(_) => !native_meta_better_than(response_tip, &local_best),
+    }
 }
 
 fn queue_native_best_sync_announce(node: &NativeNode, sync_tx: &ProtocolSender) {
@@ -6312,34 +6743,118 @@ fn queue_native_best_sync_announce(node: &NativeNode, sync_tx: &ProtocolSender) 
     }
 }
 
+fn queue_missing_blocks_from_sync_target(node: &NativeNode, sync_tx: &ProtocolSender) {
+    if node.sync_import_in_flight() {
+        return;
+    }
+    let target = node.sync_target_height.load(Ordering::Relaxed);
+    let target_hash = *node.sync_target_hash.lock();
+    let target_peer = *node.sync_target_peer.lock();
+    let best = node.best_meta();
+    let Some(range) = native_sync_observed_tip_request_range(
+        best.height,
+        best.hash,
+        target,
+        target_hash,
+        MAX_NATIVE_SYNC_RESPONSE_BLOCKS,
+        NATIVE_SYNC_REORG_BACKFILL_BLOCKS,
+    ) else {
+        return;
+    };
+    if !node.begin_outbound_sync_request(target_peer, range) {
+        debug!(
+            best_height = best.height,
+            target,
+            from_height = range.from_height,
+            to_height = range.to_height,
+            "skipping duplicate in-flight native sync target request"
+        );
+        return;
+    }
+    let request = NativeSyncMessage::Request {
+        from_height: range.from_height,
+        to_height: range.to_height,
+    };
+    let payload = match encode_sync_message(&request) {
+        Ok(payload) => payload,
+        Err(err) => {
+            warn!(error = %err, "failed to encode native sync target request");
+            return;
+        }
+    };
+    let message = DirectedProtocolMessage {
+        target: target_peer,
+        message: ProtocolMessage {
+            protocol: NATIVE_SYNC_PROTOCOL_ID,
+            payload,
+        },
+    };
+    if let Err(err) = sync_tx.try_send(message) {
+        if let Some(target_peer) = target_peer {
+            node.complete_outbound_sync_request(target_peer);
+        }
+        debug!(error = %err, "failed to queue native sync target request");
+    } else {
+        let target_peer_label = target_peer
+            .map(|peer| hex32(&peer))
+            .unwrap_or_else(|| "broadcast".to_string());
+        debug!(
+            best_height = best.height,
+            target,
+            from_height = range.from_height,
+            to_height = range.to_height,
+            target_peer = target_peer_label,
+            "queued native sync target request"
+        );
+    }
+}
+
 async fn request_missing_blocks(
     node: &NativeNode,
     handle: &ProtocolHandle,
     peer_id: PeerId,
     announced_height: u64,
+    announced_hash: Option<[u8; 32]>,
 ) {
-    let best_height = node.best_meta().height;
-    let input = NativeSyncMissingRequestInput {
-        best_height,
+    node.observe_pending_sync_peer_tip(Some(peer_id), announced_height, announced_hash);
+    if node.sync_import_in_flight() {
+        debug!(
+            peer = %hex32(&peer_id),
+            announced_height,
+            "deferring missing native sync request while import is active"
+        );
+        return;
+    }
+    let best = node.best_meta();
+    let Some(range) = native_sync_observed_tip_request_range(
+        best.height,
+        best.hash,
         announced_height,
-        max_blocks: MAX_NATIVE_SYNC_RESPONSE_BLOCKS,
-    };
-    let Some(admitted_range) = native_sync_missing_request_range(input) else {
+        announced_hash,
+        MAX_NATIVE_SYNC_RESPONSE_BLOCKS,
+        NATIVE_SYNC_REORG_BACKFILL_BLOCKS,
+    ) else {
         return;
     };
-    let range = native_sync_missing_request_range_apply_reorg_backfill(
-        input,
-        admitted_range,
-        NATIVE_SYNC_REORG_BACKFILL_BLOCKS,
-    );
+    if !node.begin_outbound_sync_request(Some(peer_id), range) {
+        debug!(
+            peer = %hex32(&peer_id),
+            best_height = best.height,
+            announced_height,
+            from_height = range.from_height,
+            to_height = range.to_height,
+            "skipping duplicate in-flight native sync request"
+        );
+        return;
+    }
     debug!(
-        best_height,
+        best_height = best.height,
         announced_height,
         from_height = range.from_height,
         to_height = range.to_height,
         "requesting missing native sync blocks"
     );
-    send_sync_message(
+    let queued = send_sync_message(
         handle,
         peer_id,
         NativeSyncMessage::Request {
@@ -6348,30 +6863,39 @@ async fn request_missing_blocks(
         },
     )
     .await;
+    if !queued {
+        node.complete_outbound_sync_request(peer_id);
+    }
 }
 
-async fn send_sync_message(handle: &ProtocolHandle, peer_id: PeerId, message: NativeSyncMessage) {
+async fn send_sync_message(
+    handle: &ProtocolHandle,
+    peer_id: PeerId,
+    message: NativeSyncMessage,
+) -> bool {
     let label = native_sync_message_label(&message);
     let payload = match encode_sync_message(&message) {
         Ok(payload) => payload,
         Err(err) => {
             warn!(error = %err, "failed to encode native sync message");
-            return;
+            return false;
         }
     };
     if let Err(err) = handle.send_to(peer_id, payload).await {
         warn!(error = %err, "failed to send native sync message");
+        false
     } else {
         info!(
             peer = %hex32(&peer_id),
             message = label,
             "queued native sync message"
         );
+        true
     }
 }
 
-async fn send_sync_response(
-    handle: &ProtocolHandle,
+async fn send_sync_response_with_sender(
+    sync_tx: &ProtocolSender,
     peer_id: PeerId,
     best_height: u64,
     blocks: Vec<NativeBlockMeta>,
@@ -6391,8 +6915,18 @@ async fn send_sync_response(
             return;
         }
     };
-    if let Err(err) = handle.send_to(peer_id, payload).await {
-        warn!(error = %err, "failed to send native sync response");
+    let message = DirectedProtocolMessage {
+        target: Some(peer_id),
+        message: ProtocolMessage {
+            protocol: NATIVE_SYNC_PROTOCOL_ID,
+            payload,
+        },
+    };
+    if let Err(err) = sync_tx.try_send(message) {
+        warn!(
+            error = %err,
+            "dropped native sync response because the protocol queue is full"
+        );
     } else {
         info!(
             peer = %hex32(&peer_id),
@@ -10560,17 +11094,55 @@ fn native_sync_missing_request_range_with_reorg_backfill(
     ))
 }
 
+fn native_sync_observed_tip_request_range(
+    best_height: u64,
+    best_hash: [u8; 32],
+    announced_height: u64,
+    announced_hash: Option<[u8; 32]>,
+    max_blocks: u64,
+    backfill_blocks: u64,
+) -> Option<NativeSyncRange> {
+    let input = NativeSyncMissingRequestInput {
+        best_height,
+        announced_height,
+        max_blocks,
+    };
+    if let Some(admitted_range) = native_sync_missing_request_range(input) {
+        let gap = announced_height.saturating_sub(best_height);
+        if gap > max_blocks {
+            return Some(admitted_range);
+        }
+        return Some(native_sync_missing_request_range_apply_reorg_backfill(
+            input,
+            admitted_range,
+            backfill_blocks,
+        ));
+    }
+
+    if announced_height == 0
+        || announced_height != best_height
+        || announced_hash.is_none_or(|hash| hash == best_hash)
+        || max_blocks == 0
+    {
+        return None;
+    }
+
+    let from_height = announced_height
+        .saturating_sub(backfill_blocks)
+        .saturating_add(1);
+    Some(NativeSyncRange {
+        from_height,
+        to_height: announced_height.min(from_height.saturating_add(max_blocks - 1)),
+    })
+}
+
 fn native_sync_missing_request_range_apply_reorg_backfill(
     input: NativeSyncMissingRequestInput,
     range: NativeSyncRange,
     backfill_blocks: u64,
 ) -> NativeSyncRange {
     let gap = input.announced_height.saturating_sub(input.best_height);
-    if gap == 0
-        || backfill_blocks == 0
-        || gap > backfill_blocks
-        || input.max_blocks <= backfill_blocks
-    {
+    if gap == 0 || backfill_blocks == 0 || input.max_blocks <= backfill_blocks {
         return range;
     }
 
@@ -19548,6 +20120,140 @@ mod tests {
     }
 
     #[test]
+    fn sync_response_skips_unknown_nonwinning_backfill_without_replay() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let test_pow_bits = 0x207f_ffff;
+        let node = NativeNode::open(test_config(tmp.path(), test_pow_bits, "unsafe", false))
+            .expect("node");
+        let genesis = node.best_meta();
+
+        let canonical_work = node.prepare_work().expect("prepare canonical native work");
+        let canonical_seal = strongest_test_seal(&canonical_work, 0..512);
+        let canonical = node
+            .import_mined_block(&canonical_work, canonical_seal)
+            .expect("canonical import")
+            .expect("canonical block");
+        assert_eq!(node.best_meta().hash, canonical.hash);
+
+        let stale_side = (1..128)
+            .map(|round| mined_empty_child(&genesis, 1, test_pow_bits, round))
+            .find(|candidate| !native_meta_better_than(candidate, &canonical))
+            .expect("nonwinning side child");
+        assert!(
+            node.header_by_hash(&stale_side.hash)
+                .expect("side child lookup")
+                .is_none(),
+            "test setup should start with an unknown stale side block"
+        );
+
+        let report = import_native_sync_response_blocks(
+            &node,
+            vec![stale_side.clone()],
+            canonical.height,
+            NativeSyncResponseImportProgress::new(1),
+        );
+
+        assert!(
+            report.failure.is_none(),
+            "unexpected sync import failure: {:?}",
+            report.failure.as_ref().map(|failure| (
+                failure.height,
+                hex32(&failure.hash),
+                failure.error.clone()
+            ))
+        );
+        assert_eq!(report.progress.attempted_blocks, 1);
+        assert_eq!(report.progress.imported_blocks, 0);
+        assert_eq!(node.best_meta().hash, canonical.hash);
+        assert!(
+            node.header_by_hash(&stale_side.hash)
+                .expect("side child lookup after sync import")
+                .is_none(),
+            "sync backfill must not replay or persist unknown nonwinning side branches"
+        );
+    }
+
+    #[test]
+    fn sync_response_higher_peer_tip_imports_reorg_prefix() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let test_pow_bits = 0x207f_ffff;
+        let node = NativeNode::open(test_config(tmp.path(), test_pow_bits, "unsafe", false))
+            .expect("node");
+        let genesis = node.best_meta();
+
+        for height in 1..=3 {
+            let work = node.prepare_work().expect("prepare local branch work");
+            let seal = strongest_test_seal(&work, (height * 16)..(height * 16 + 16));
+            let local = node
+                .import_mined_block(&work, seal)
+                .expect("local branch mined import")
+                .expect("local branch block");
+            assert_eq!(local.height, height);
+        }
+        let local_best = node.best_meta();
+        assert_eq!(local_best.height, 3);
+
+        let peer_tmp = tempfile::tempdir().expect("peer tempdir");
+        let peer_node =
+            NativeNode::open(test_config(peer_tmp.path(), test_pow_bits, "unsafe", false))
+                .expect("peer node");
+        assert_eq!(peer_node.best_meta().hash, genesis.hash);
+        let mut peer_blocks = Vec::new();
+        for height in 1..=5 {
+            let work = peer_node.prepare_work().expect("prepare peer branch work");
+            let seal = strongest_test_seal(&work, (100 + height * 16)..(116 + height * 16));
+            let peer = peer_node
+                .import_mined_block(&work, seal)
+                .expect("peer branch mined import")
+                .expect("peer branch block");
+            assert_eq!(peer.height, height);
+            peer_blocks.push(peer);
+        }
+        let peer_tip = peer_node.best_meta();
+        assert!(
+            !native_meta_better_than(&peer_blocks[0], &local_best),
+            "first peer prefix block should not individually beat the local tip"
+        );
+
+        let report = import_native_sync_response_blocks(
+            &node,
+            peer_blocks.clone(),
+            peer_tip.height,
+            NativeSyncResponseImportProgress::new(peer_blocks.len()),
+        );
+
+        assert!(
+            report.failure.is_none(),
+            "unexpected sync import failure: {:?}",
+            report.failure.as_ref().map(|failure| (
+                failure.height,
+                hex32(&failure.hash),
+                failure.error.clone()
+            ))
+        );
+        assert_eq!(report.progress.attempted_blocks, peer_blocks.len());
+        assert!(report.progress.imported_blocks >= 2);
+        assert_eq!(node.best_meta().hash, peer_tip.hash);
+        assert_eq!(node.best_meta().height, peer_tip.height);
+        for peer in peer_blocks {
+            assert_eq!(
+                node.header_by_hash(&peer.hash)
+                    .expect("peer block lookup")
+                    .expect("peer block stored")
+                    .hash,
+                peer.hash
+            );
+            assert_eq!(
+                node.hash_by_height(peer.height)
+                    .expect("canonical height lookup"),
+                Some(peer.hash),
+                "peer branch should become canonical at height {}",
+                peer.height
+            );
+        }
+    }
+
+    #[test]
     fn reorg_replay_rechecks_historical_side_branch_artifacts_before_publish() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let test_pow_bits = 0x207f_ffff;
@@ -22182,6 +22888,44 @@ mod tests {
         );
         assert!(unsafe_snapshot.get("basePath").is_some());
         assert!(unsafe_snapshot.get("p2pListenAddr").is_some());
+    }
+
+    #[test]
+    fn approved_seeded_dev_profile_reports_public_testnet_identity() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut config = test_config(tmp.path(), 0x207f_ffff, "safe", false);
+        config.seeds.push(APPROVED_PUBLIC_JOIN_SEEDS.to_string());
+        let node = NativeNode::open(config).expect("node");
+
+        let safe_snapshot =
+            dispatch_rpc_method(&node, "hegemon_nodeConfig", Value::Array(Vec::new()))
+                .expect("safe config snapshot");
+        assert_eq!(
+            safe_snapshot.get("chainSpecId"),
+            Some(&json!("hegemon-native-testnet"))
+        );
+        assert_eq!(safe_snapshot.get("chainType"), Some(&json!("testnet")));
+        assert_eq!(
+            dispatch_rpc_method(&node, "system_chain", Value::Array(Vec::new()))
+                .expect("system chain"),
+            json!("Hegemon")
+        );
+
+        let private_tmp = tempfile::tempdir().expect("tempdir");
+        let private_node =
+            NativeNode::open(test_config(private_tmp.path(), 0x207f_fffe, "safe", false))
+                .expect("private dev node");
+        let private_snapshot = dispatch_rpc_method(
+            &private_node,
+            "hegemon_nodeConfig",
+            Value::Array(Vec::new()),
+        )
+        .expect("private config snapshot");
+        assert_eq!(
+            private_snapshot.get("chainSpecId"),
+            Some(&json!("hegemon-native-dev"))
+        );
+        assert_eq!(private_snapshot.get("chainType"), Some(&json!("dev")));
     }
 
     #[test]
@@ -33651,7 +34395,7 @@ mod tests {
             NATIVE_SYNC_REORG_BACKFILL_BLOCKS,
         )
         .expect("near-tip announced fork should request a bounded backfill range");
-        assert_eq!(range.from_height, 20465);
+        assert_eq!(range.from_height, 20561);
         assert_eq!(range.to_height, 20618);
 
         let straight_sync = native_sync_missing_request_range_with_reorg_backfill(
@@ -33668,15 +34412,31 @@ mod tests {
     }
 
     #[test]
-    fn native_sync_bootstrap_request_backfills_low_divergent_tip() {
+    fn native_sync_large_gap_request_still_backfills_reorg_window() {
+        let range = native_sync_missing_request_range_with_reorg_backfill(
+            NativeSyncMissingRequestInput {
+                best_height: 4614,
+                announced_height: 4960,
+                max_blocks: MAX_NATIVE_SYNC_RESPONSE_BLOCKS,
+            },
+            NATIVE_SYNC_REORG_BACKFILL_BLOCKS,
+        )
+        .expect("higher peer branch should request enough local prefix to find a fork point");
+
+        assert_eq!(range.from_height, 4583);
+        assert_eq!(range.to_height, 4710);
+    }
+
+    #[test]
+    fn native_sync_bootstrap_request_after_first_chunk_starts_after_local_best() {
         let range = native_sync_missing_request_range(NativeSyncMissingRequestInput {
             best_height: 145,
             announced_height: 21_971,
             max_blocks: MAX_NATIVE_SYNC_RESPONSE_BLOCKS,
         })
-        .expect("low divergent bootstrap should request the first bounded window");
-        assert_eq!(range.from_height, 1);
-        assert_eq!(range.to_height, MAX_NATIVE_SYNC_RESPONSE_BLOCKS);
+        .expect("post-bootstrap catch-up should request the next bounded window");
+        assert_eq!(range.from_height, 146);
+        assert_eq!(range.to_height, 273);
     }
 
     #[test]
@@ -33769,6 +34529,42 @@ mod tests {
     }
 
     #[test]
+    fn bootstrap_authoring_with_seed_starts_open_until_higher_target_observed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut config = test_config(tmp.path(), 0x207f_ffff, "safe", false);
+        config.seeds.push(APPROVED_PUBLIC_JOIN_SEEDS.to_string());
+        config.bootstrap_mining_authoring = true;
+        let node = NativeNode::open(config).expect("node");
+
+        assert!(node.mining_sync_gate_allows_work());
+        let (syncing, target) = node.sync_status_fields();
+        assert!(!syncing);
+        assert_eq!(target, 0);
+
+        node.observe_pending_sync_peer_height(node.best_meta().height + 1);
+        assert!(!node.mining_sync_gate_allows_work());
+    }
+
+    #[test]
+    fn pending_sync_target_keeps_status_syncing_without_opening_mining_gate() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut config = test_config(tmp.path(), 0x207f_ffff, "safe", false);
+        config.seeds.push("127.0.0.1:30333".to_string());
+        let node = NativeNode::open(config).expect("node");
+        for _ in 0..2 {
+            mine_empty_native_block(&node);
+        }
+
+        let target = node.best_meta().height + 10;
+        node.observe_pending_sync_peer_height(target);
+
+        let (syncing, observed_target) = node.sync_status_fields();
+        assert!(syncing);
+        assert_eq!(observed_target, target);
+        assert!(!node.mining_sync_gate_allows_work());
+    }
+
+    #[test]
     fn empty_seed_live_mining_gate_ignores_observed_open_without_bootstrap_authoring() {
         assert!(!native_mining_gate_allows_work(NativeMiningGateInput {
             has_seeds: false,
@@ -33811,11 +34607,190 @@ mod tests {
             local_best_height: best.height,
             peer_best_height: best.height,
             stopped_on_error: false,
-        })
-        .expect("known equal-height announce should produce sync evidence");
-        node.observe_verified_sync_peer_height(observed);
+        });
+        assert_eq!(observed, Some(best.height));
+        node.observe_verified_sync_peer_height(observed.expect("observed local tip"));
         assert_eq!(node.sync_target_height.load(Ordering::Relaxed), best.height);
         assert!(node.mining_sync_gate_allows_work());
+        let (syncing, target) = node.sync_status_fields();
+        assert!(!syncing);
+        assert_eq!(target, best.height);
+    }
+
+    #[test]
+    fn seeded_mining_gate_stays_closed_after_partial_sync_progress() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut config = test_config(tmp.path(), 0x207f_ffff, "safe", false);
+        config.seeds.push("127.0.0.1:30333".to_string());
+        let node = NativeNode::open(config).expect("node");
+        for _ in 0..2 {
+            mine_empty_native_block(&node);
+        }
+        let local_best = node.best_meta();
+        let peer_best_height = local_best.height + 4_096;
+
+        let observed = native_mining_sync_observed_peer_height(NativeMiningSyncEvidenceInput {
+            verified_new_progress: true,
+            verified_known_at_or_below_local_best: false,
+            local_best_height: local_best.height,
+            peer_best_height,
+            stopped_on_error: false,
+        })
+        .expect("verified partial sync progress should produce sync evidence");
+        node.observe_verified_sync_peer_height(observed);
+
+        assert_eq!(
+            node.sync_target_height.load(Ordering::Relaxed),
+            peer_best_height
+        );
+        assert!(!node.mining_sync_gate_allows_work());
+        let (syncing, target) = node.sync_status_fields();
+        assert!(syncing);
+        assert_eq!(target, peer_best_height);
+    }
+
+    #[test]
+    fn same_height_unknown_peer_tip_keeps_seeded_node_syncing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut config = test_config(tmp.path(), 0x207f_ffff, "safe", false);
+        config.seeds.push("127.0.0.1:30333".to_string());
+        let node = NativeNode::open(config).expect("node");
+        for _ in 0..2 {
+            mine_empty_native_block(&node);
+        }
+
+        let best = node.best_meta();
+        let mut peer_hash = [0x42; 32];
+        if peer_hash == best.hash {
+            peer_hash[0] ^= 1;
+        }
+        node.observe_pending_sync_peer_tip(Some([0x24; 32]), best.height, Some(peer_hash));
+
+        let (syncing, target) = node.sync_status_fields();
+        assert!(syncing);
+        assert_eq!(target, best.height);
+        assert!(!node.mining_sync_gate_allows_work());
+        assert_eq!(*node.sync_target_peer.lock(), Some([0x24; 32]));
+    }
+
+    #[test]
+    fn same_height_fork_tip_requests_bounded_reorg_window() {
+        let best_hash = [0x11; 32];
+        let peer_hash = [0x22; 32];
+        let range = native_sync_observed_tip_request_range(
+            5_016,
+            best_hash,
+            5_016,
+            Some(peer_hash),
+            MAX_NATIVE_SYNC_RESPONSE_BLOCKS,
+            NATIVE_SYNC_REORG_BACKFILL_BLOCKS,
+        )
+        .expect("same-height fork tip should request reorg backfill");
+        assert_eq!(range.from_height, 4_985);
+        assert_eq!(range.to_height, 5_016);
+
+        assert_eq!(
+            native_sync_observed_tip_request_range(
+                5_016,
+                best_hash,
+                5_016,
+                Some(best_hash),
+                MAX_NATIVE_SYNC_RESPONSE_BLOCKS,
+                NATIVE_SYNC_REORG_BACKFILL_BLOCKS,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn large_gap_observed_tip_requests_straight_catch_up_window() {
+        let range = native_sync_observed_tip_request_range(
+            896,
+            [0x11; 32],
+            5_039,
+            Some([0x22; 32]),
+            MAX_NATIVE_SYNC_RESPONSE_BLOCKS,
+            NATIVE_SYNC_REORG_BACKFILL_BLOCKS,
+        )
+        .expect("large-gap public join should request the next catch-up chunk");
+
+        assert_eq!(range.from_height, 897);
+        assert_eq!(range.to_height, 1_024);
+    }
+
+    #[test]
+    fn native_sync_response_in_flight_deduplicates_peer() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let node =
+            NativeNode::open(test_config(tmp.path(), 0x207f_ffff, "safe", false)).expect("node");
+        let peer = [0x44; 32];
+
+        assert!(node.begin_sync_response_for_peer(peer));
+        assert!(!node.begin_sync_response_for_peer(peer));
+        node.end_sync_response_for_peer(peer);
+        assert!(node.begin_sync_response_for_peer(peer));
+        node.end_sync_response_for_peer(peer);
+    }
+
+    #[test]
+    fn outbound_native_sync_request_deduplicates_peer_range() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let node =
+            NativeNode::open(test_config(tmp.path(), 0x207f_ffff, "safe", false)).expect("node");
+        let peer = [0x45; 32];
+        let range = NativeSyncRange {
+            from_height: 769,
+            to_height: 1_280,
+        };
+
+        assert!(node.begin_outbound_sync_request(Some(peer), range));
+        assert!(!node.begin_outbound_sync_request(Some(peer), range));
+        assert!(node.begin_outbound_sync_request(
+            Some(peer),
+            NativeSyncRange {
+                from_height: 1_153,
+                to_height: 1_664,
+            },
+        ));
+        node.complete_outbound_sync_request(peer);
+        assert!(node.begin_outbound_sync_request(Some(peer), range));
+    }
+
+    #[test]
+    fn stale_native_sync_response_is_dropped_before_import() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let node =
+            NativeNode::open(test_config(tmp.path(), 0x207f_ffff, "safe", false)).expect("node");
+        for _ in 0..2 {
+            mine_empty_native_block(&node);
+        }
+        let best = node.best_meta();
+
+        assert!(native_sync_response_stale_for_local_tip(
+            &node,
+            best.height,
+            &[]
+        ));
+        assert!(native_sync_response_stale_for_local_tip(
+            &node,
+            best.height,
+            std::slice::from_ref(&best)
+        ));
+
+        let mut better_same_height = best.clone();
+        better_same_height.hash = [0x7a; 32];
+        better_same_height.cumulative_work = [0xff; 48];
+        assert!(!native_sync_response_stale_for_local_tip(
+            &node,
+            best.height,
+            &[better_same_height]
+        ));
+
+        assert!(!native_sync_response_stale_for_local_tip(
+            &node,
+            best.height + 1,
+            &[]
+        ));
     }
 
     #[test]
@@ -33835,10 +34810,20 @@ mod tests {
                 verified_new_progress: false,
                 verified_known_at_or_below_local_best: true,
                 local_best_height: 10,
-                peer_best_height: 11,
+                peer_best_height: 10,
                 stopped_on_error: false,
             }),
-            None
+            Some(10)
+        );
+        assert_eq!(
+            native_mining_sync_observed_peer_height(NativeMiningSyncEvidenceInput {
+                verified_new_progress: false,
+                verified_known_at_or_below_local_best: true,
+                local_best_height: 10,
+                peer_best_height: 9,
+                stopped_on_error: false,
+            }),
+            Some(10)
         );
     }
 

--- a/node/src/native/mod.rs
+++ b/node/src/native/mod.rs
@@ -6826,13 +6826,18 @@ async fn request_missing_blocks(
         return;
     }
     let best = node.best_meta();
-    let Some(range) = native_sync_observed_tip_request_range(
-        best.height,
-        best.hash,
+    let missing_request_input = NativeSyncMissingRequestInput {
+        best_height: best.height,
         announced_height,
+        max_blocks: MAX_NATIVE_SYNC_RESPONSE_BLOCKS,
+    };
+    let admitted_missing_range = native_sync_missing_request_range(missing_request_input);
+    let Some(range) = native_sync_observed_tip_request_range_from_admitted_missing(
+        missing_request_input,
+        best.hash,
         announced_hash,
-        MAX_NATIVE_SYNC_RESPONSE_BLOCKS,
         NATIVE_SYNC_REORG_BACKFILL_BLOCKS,
+        admitted_missing_range,
     ) else {
         return;
     };
@@ -11107,9 +11112,26 @@ fn native_sync_observed_tip_request_range(
         announced_height,
         max_blocks,
     };
-    if let Some(admitted_range) = native_sync_missing_request_range(input) {
-        let gap = announced_height.saturating_sub(best_height);
-        if gap > max_blocks {
+    let admitted_missing_range = native_sync_missing_request_range(input);
+    native_sync_observed_tip_request_range_from_admitted_missing(
+        input,
+        best_hash,
+        announced_hash,
+        backfill_blocks,
+        admitted_missing_range,
+    )
+}
+
+fn native_sync_observed_tip_request_range_from_admitted_missing(
+    input: NativeSyncMissingRequestInput,
+    best_hash: [u8; 32],
+    announced_hash: Option<[u8; 32]>,
+    backfill_blocks: u64,
+    admitted_missing_range: Option<NativeSyncRange>,
+) -> Option<NativeSyncRange> {
+    if let Some(admitted_range) = admitted_missing_range {
+        let gap = input.announced_height.saturating_sub(input.best_height);
+        if gap > input.max_blocks {
             return Some(admitted_range);
         }
         return Some(native_sync_missing_request_range_apply_reorg_backfill(
@@ -11119,20 +11141,23 @@ fn native_sync_observed_tip_request_range(
         ));
     }
 
-    if announced_height == 0
-        || announced_height != best_height
+    if input.announced_height == 0
+        || input.announced_height != input.best_height
         || announced_hash.is_none_or(|hash| hash == best_hash)
-        || max_blocks == 0
+        || input.max_blocks == 0
     {
         return None;
     }
 
-    let from_height = announced_height
+    let from_height = input
+        .announced_height
         .saturating_sub(backfill_blocks)
         .saturating_add(1);
     Some(NativeSyncRange {
         from_height,
-        to_height: announced_height.min(from_height.saturating_add(max_blocks - 1)),
+        to_height: input
+            .announced_height
+            .min(from_height.saturating_add(input.max_blocks - 1)),
     })
 }
 

--- a/runbooks/authoring_pool_upgrade.md
+++ b/runbooks/authoring_pool_upgrade.md
@@ -21,7 +21,7 @@ Before doing any server work, follow [config/testnet-initialization.md](/Users/p
 All mining hosts must share the same approved bootstrap seeds:
 
 ```bash
-HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333"
+HEGEMON_SEEDS="hegemon.pauli.group:30333"
 ```
 
 If you are bringing up the first public authoring node after a full reset, do not seed it to itself. Start that first node with `HEGEMON_SEEDS` unset only when `HEGEMON_BOOTSTRAP_AUTHORING=1` is also set, then remove the bootstrap override and use the approved public join seed list on every other miner and relay.

--- a/runbooks/bootnode_setup.md
+++ b/runbooks/bootnode_setup.md
@@ -12,7 +12,7 @@ This guide covers the native Hegemon boot node. The node is the `hegemon-node` b
 All operators on the same network should use the approved seed list:
 
 ```bash
-export HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333"
+export HEGEMON_SEEDS="hegemon.pauli.group:30333"
 ```
 
 Miners must share the same seed list to avoid partitions and accidental forks. PoW timestamps are rejected if they exceed the future-skew bound, so keep host time synchronized with NTP/chrony.
@@ -63,7 +63,7 @@ User=hegemon
 Group=hegemon
 Environment="RUST_LOG=info"
 Environment="RUST_BACKTRACE=1"
-Environment="HEGEMON_SEEDS=devnet.hegemonprotocol.com:30333"
+Environment="HEGEMON_SEEDS=hegemon.pauli.group:30333"
 Environment="HEGEMON_MAX_PEERS=64"
 ExecStart=/usr/local/bin/hegemon-node \
     --dev \
@@ -110,7 +110,7 @@ For a non-mining seed, `system_health` should show the node is alive and whether
 ## Verification Checklist
 
 - [ ] `make node` built the native `hegemon-node`.
-- [ ] `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333"` is set or deliberately rotated for the whole network.
+- [ ] `HEGEMON_SEEDS="hegemon.pauli.group:30333"` is set or deliberately rotated for the whole network.
 - [ ] NTP/chrony is enabled and healthy.
 - [ ] Port `30333/tcp` is reachable.
 - [ ] RPC is not publicly exposed unless intentionally protected.

--- a/runbooks/miner_wallet_quickstart.md
+++ b/runbooks/miner_wallet_quickstart.md
@@ -65,7 +65,7 @@ HEGEMON_MINE=1 HEGEMON_MINER_ADDRESS="$HEGEMON_MINER_ADDRESS" \
 To avoid forks caused by low peer counts, configure multiple reachable seeds. Use a comma-separated list in `HEGEMON_SEEDS`:
 
 ```bash
-export HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333"
+export HEGEMON_SEEDS="hegemon.pauli.group:30333"
 ```
 
 Ensure TCP/30333 is open on each approved seed and that every miner shares the same seed list. The node refuses live `HEGEMON_MINE=1` authoring with an empty seed list unless `HEGEMON_BOOTSTRAP_AUTHORING=1` is set for a deliberate first-author bootstrap.

--- a/runbooks/p2p_node_vps.md
+++ b/runbooks/p2p_node_vps.md
@@ -55,7 +55,7 @@ NODE_BASE_PATH=/var/lib/hegemon-node
 NODE_PORT=30333
 NODE_RPC_PORT=9944
 # Approved shared seed list. All miners/operators should use the same value.
-HEGEMON_SEEDS=devnet.hegemonprotocol.com:30333
+HEGEMON_SEEDS=hegemon.pauli.group:30333
 # Set to 1 to mine on this host.
 HEGEMON_MINE=0
 ENV

--- a/runbooks/two_node_remote_setup.md
+++ b/runbooks/two_node_remote_setup.md
@@ -193,7 +193,7 @@ HEGEMON_SEEDS="<YOUR_PUBLIC_IP>:30333" \
   --name "FriendNode"
 ```
 
-Use the same agreed `HEGEMON_SEEDS` list on every miner. Diverging seed lists can partition peers and cause forks. If you are joining the shared public fresh testnet instead of bootstrapping your own two-node network, the current approved public join seed is `devnet.hegemonprotocol.com:30333`.
+Use the same agreed `HEGEMON_SEEDS` list on every miner. Diverging seed lists can partition peers and cause forks. If you are joining the shared public fresh testnet instead of bootstrapping your own two-node network, the current approved public join seed is `hegemon.pauli.group:30333`.
 
 ---
 
@@ -268,7 +268,7 @@ This ensures both nodes can reconnect if either restarts.
 
 Use the Hegemon desktop app (`hegemon-app/`) from your local machine:
 
-1. Run a local relay node that connects over P2P to the remote miner. For ad hoc two-node tests, set `HEGEMON_SEEDS="<FRIEND_PUBLIC_IP>:30333"`; for the shared testnet, use the approved seed list instead: `HEGEMON_SEEDS="devnet.hegemonprotocol.com:30333"`.
+1. Run a local relay node that connects over P2P to the remote miner. For ad hoc two-node tests, set `HEGEMON_SEEDS="<FRIEND_PUBLIC_IP>:30333"`; for the shared testnet, use the approved seed list instead: `HEGEMON_SEEDS="hegemon.pauli.group:30333"`.
 2. Point the desktop app at the local relay RPC endpoint, for example `ws://127.0.0.1:9944`.
 3. Create or open a wallet store.
 4. Sync the wallet and send funds to your friend's address.

--- a/scripts/check-app-launch-autostart.mjs
+++ b/scripts/check-app-launch-autostart.mjs
@@ -10,7 +10,7 @@ const APP_PATH =
   process.env.HEGEMON_APP_BUNDLE ?? path.join(ROOT_DIR, 'hegemon-app/dist/mac-arm64/Hegemon.app');
 const BUNDLE_ID = process.env.HEGEMON_APP_BUNDLE_ID ?? 'com.hegemon.desktop';
 const RPC_URL = process.env.HEGEMON_APP_AUTOSTART_RPC_URL ?? 'http://127.0.0.1:9955';
-const APPROVED_SEED = process.env.HEGEMON_APP_EXPECTED_SEED ?? 'devnet.hegemonprotocol.com:30333';
+const APPROVED_SEED = process.env.HEGEMON_APP_EXPECTED_SEED ?? 'hegemon.pauli.group:30333';
 const RPC_DOWN_TIMEOUT_MS = Number.parseInt(
   process.env.HEGEMON_APP_AUTOSTART_RPC_DOWN_TIMEOUT_MS ?? '45000',
   10
@@ -286,7 +286,7 @@ async function main() {
     return await rpcReachable();
   });
 
-  const liveSnapshot = await waitFor('packaged app to reach live 0.10 devnet P2P state', LIVE_TIMEOUT_MS, async () => {
+  const liveSnapshot = await waitFor('packaged app to reach live Hegemon testnet P2P state', LIVE_TIMEOUT_MS, async () => {
     const snapshot = await readSnapshot();
     const lag = Math.max(0, snapshot.target - snapshot.height);
     const healthy =
@@ -300,7 +300,7 @@ async function main() {
   });
 
   const summary = summarizeSnapshot(liveSnapshot);
-  log('PASS packaged app autostarted a local loopback node and reached live 0.10 devnet P2P');
+  log('PASS packaged app autostarted a local loopback node and reached live Hegemon testnet P2P');
   console.log(JSON.stringify(summary, null, 2));
 }
 

--- a/scripts/generate-testnet-keys.sh
+++ b/scripts/generate-testnet-keys.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 KEYS_DIR="${KEYS_DIR:-./keys}"
 NODE_COUNT="${NODE_COUNT:-3}"
-APPROVED_SEEDS="${HEGEMON_SEEDS:-devnet.hegemonprotocol.com:30333}"
+APPROVED_SEEDS="${HEGEMON_SEEDS:-hegemon.pauli.group:30333}"
 
 mkdir -p "$KEYS_DIR"
 

--- a/scripts/start-mining.sh
+++ b/scripts/start-mining.sh
@@ -167,10 +167,10 @@ else
     if [[ -n "${BOOTNODE:-}" ]]; then
         export HEGEMON_SEEDS="$(seed_from_bootnode "$BOOTNODE")"
     else
-        export HEGEMON_SEEDS="${HEGEMON_SEEDS:-devnet.hegemonprotocol.com:30333}"
+        export HEGEMON_SEEDS="${HEGEMON_SEEDS:-hegemon.pauli.group:30333}"
     fi
     if [[ -z "$HEGEMON_SEEDS" ]]; then
-        echo "ERROR: HEGEMON_SEEDS is empty. Use HEGEMON_SEEDS=\"devnet.hegemonprotocol.com:30333\" or set HEGEMON_LOCAL_DEV_MINING=1 for isolated dev mining." >&2
+        echo "ERROR: HEGEMON_SEEDS is empty. Use HEGEMON_SEEDS=\"hegemon.pauli.group:30333\" or set HEGEMON_LOCAL_DEV_MINING=1 for isolated dev mining." >&2
         exit 1
     fi
     echo "Mode: shared mining"


### PR DESCRIPTION
## Summary
- make the public 0.10 testnet path use `hegemon.pauli.group:30333` consistently across app defaults, skills, scripts, and runbooks
- fix native sync truth so same-height forked tips stay marked as syncing until the target hash matches
- keep cold public joins moving by de-duplicating sync requests/responses, serving block ranges off the main sync loop, dropping stale responses, and using bounded 128-block catch-up chunks
- improve peer address propagation and peer snapshot reporting for public joins
- update `crossbeam-epoch`/`crossbeam-deque` so the dependency audit has 0 unwaived findings

## Live validation
- Deployed the patched node binary to `hegemon-ovh` and `hegemon-dev`.
- Both miners converged to the same public testnet tip after the sync fix.
- A fresh local node joined via `HEGEMON_SEEDS="hegemon.pauli.group:30333"` with no SSH and reached the matching live tip hash before reporting `syncing=false`.

## Tests
- `npm --prefix hegemon-app run typecheck`
- `npm --prefix hegemon-app run check:ui-guards`
- `cargo test -p hegemon-node native_sync_ --lib --no-default-features -- --nocapture`
- `cargo test -p hegemon-node same_height_ --lib --no-default-features -- --nocapture`
- `cargo check -p hegemon-node --lib --no-default-features`
- `cargo check -p network --all-targets`
- `./scripts/dependency-audit-gate.sh`
- `./scripts/check-core.sh build`
- `make check` (monorepo run was executed; all captured phases passed before the terminal session ended, with release build reconfirmed by `./scripts/check-core.sh build`)